### PR TITLE
Baseline code coverage for org.apache.kafka:kafka-streams:3.6.2

### DIFF
--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CoreApiContractsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CoreApiContractsCoverageTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.BrokerNotFoundException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.InvalidStateStorePartitionException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.StreamsNotStartedException;
+import org.apache.kafka.streams.errors.StreamsRebalancingException;
+import org.apache.kafka.streams.errors.StreamsStoppedException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
+import org.apache.kafka.streams.internals.UpgradeFromValues;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.processor.BatchingStateRestoreCallback;
+import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.QuickUnion;
+import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
+import org.apache.kafka.streams.state.TimestampedBytesStore;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NO_TIMESTAMP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CoreApiContractsCoverageTest {
+
+    @Test
+    void processorRecordsAreImmutableValueObjectsWithDefensiveHeaders() {
+        RecordHeaders sourceHeaders = new RecordHeaders();
+        sourceHeaders.add("trace", new byte[]{1});
+        Record<String, Integer> record = new Record<>("key", 7, 10L, sourceHeaders);
+        sourceHeaders.add("late", new byte[]{2});
+
+        Record<String, Integer> equivalent = new Record<>(
+                "key", 7, 10L, new RecordHeaders().add("trace", new byte[]{1}));
+        Record<String, Integer> replacedHeaders = record.withHeaders(
+                new RecordHeaders().add("replacement", new byte[]{3}));
+
+        assertThat(record.headers().lastHeader("trace").value()).containsExactly(1);
+        assertThat(record.headers().lastHeader("late")).isNull();
+        assertThat(record.withTimestamp(11L).timestamp()).isEqualTo(11L);
+        assertThat(record.withKey("other").key()).isEqualTo("other");
+        assertThat(record.withValue(8).value()).isEqualTo(8);
+        assertThat(replacedHeaders.headers().lastHeader("replacement").value()).containsExactly(3);
+        assertThat(record).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(record).isNotEqualTo(replacedHeaders).isNotEqualTo(null).isNotEqualTo("record");
+        assertThat(record.toString()).contains("key=key", "value=7", "timestamp=10", "trace");
+        assertThatThrownBy(() -> new Record<>("key", "value", -1L))
+                .isInstanceOf(StreamsException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void branchingAndEmissionFactoriesEnforceTheirConfigurationContracts() {
+        Branched<String, Integer> named = Branched.<String, Integer>as("positive").withName("renamed");
+        Branched<String, Integer> function = Branched.withFunction(stream -> stream, "mapped");
+        Branched<String, Integer> unnamedFunction = Branched.withFunction(stream -> stream);
+        Branched<String, Integer> consumer = Branched.withConsumer(stream -> { }, "observed");
+        Branched<String, Integer> unnamedConsumer = Branched.withConsumer(stream -> { });
+
+        assertThat(named).isNotNull();
+        assertThat(function).isNotNull();
+        assertThat(unnamedFunction).isNotNull();
+        assertThat(consumer).isNotNull();
+        assertThat(unnamedConsumer).isNotNull();
+        assertThatNullPointerException().isThrownBy(() -> Branched.as(null));
+        assertThatNullPointerException().isThrownBy(() -> named.withName(null));
+        assertThatNullPointerException().isThrownBy(() -> Branched.withFunction(null));
+        assertThatNullPointerException().isThrownBy(() -> Branched.withConsumer(null));
+
+        EmitStrategy close = EmitStrategy.onWindowClose();
+        EmitStrategy update = EmitStrategy.onWindowUpdate();
+        assertThat(close.type()).isEqualTo(EmitStrategy.StrategyType.ON_WINDOW_CLOSE);
+        assertThat(update.type()).isEqualTo(EmitStrategy.StrategyType.ON_WINDOW_UPDATE);
+        assertThat(EmitStrategy.StrategyType.forType(close.type()).type()).isEqualTo(close.type());
+        assertThat(EmitStrategy.StrategyType.forType(update.type()).type()).isEqualTo(update.type());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void compatibilityHelpersAdaptLegacyDataWithoutLosingSemantics() {
+        byte[] plainValue = new byte[]{4, 5, 6};
+        byte[] timestamped = TimestampedBytesStore.convertToTimestampedFormat(plainValue);
+        ByteBuffer decoded = ByteBuffer.wrap(timestamped);
+
+        assertThat(decoded.getLong()).isEqualTo(NO_TIMESTAMP);
+        assertThat(new byte[]{decoded.get(), decoded.get(), decoded.get()}).containsExactly(plainValue);
+        assertThat(TimestampedBytesStore.convertToTimestampedFormat(null)).isNull();
+        assertThat(UpgradeFromValues.getValueFromString("3.5"))
+                .isEqualTo(UpgradeFromValues.UPGRADE_FROM_35)
+                .hasToString("3.5");
+
+        StreamPartitioner<String, String> selected = (topic, key, value, count) -> 2;
+        StreamPartitioner<String, String> defaulted = (topic, key, value, count) -> null;
+        assertThat(selected.partitions("output", "key", "value", 4)).contains(Set.of(2));
+        assertThat(defaulted.partitions("output", "key", "value", 4)).isEqualTo(Optional.empty());
+
+        BatchingStateRestoreCallback callback = records -> {
+            assertThat(records).hasSize(1);
+            KeyValue<byte[], byte[]> restored = records.iterator().next();
+            assertThat(restored.key).containsExactly(1);
+            assertThat(restored.value).containsExactly(2);
+        };
+        callback.restoreAll(List.of(KeyValue.pair(new byte[]{1}, new byte[]{2})));
+        assertThatThrownBy(() -> callback.restore(new byte[]{1}, new byte[]{2}))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void timestampExtractorsRejectOrRecoverFromInvalidBrokerTimestamps() {
+        ConsumerRecord<Object, Object> valid = new ConsumerRecord<>(
+                "events", 1, 4L, 25L, TimestampType.CREATE_TIME, -1L, -1, -1, "key", "value");
+        FailOnInvalidTimestamp strict = new FailOnInvalidTimestamp();
+        UsePartitionTimeOnInvalidTimestamp fallback = new UsePartitionTimeOnInvalidTimestamp();
+        WallclockTimestampExtractor wallclock = new WallclockTimestampExtractor();
+
+        assertThat(strict.extract(valid, 30L)).isEqualTo(25L);
+        assertThat(fallback.extract(valid, 30L)).isEqualTo(25L);
+        assertThat(wallclock.extract(valid, 30L)).isPositive();
+
+        ConsumerRecord<Object, Object> missing = new ConsumerRecord<>("events", 1, -1L, "key", "value");
+        assertThatThrownBy(() -> strict.extract(missing, 30L))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("invalid (negative) timestamp");
+        assertThat(fallback.extract(missing, 30L)).isEqualTo(30L);
+        assertThatThrownBy(() -> fallback.extract(missing, -1L))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("partition time is unknown");
+    }
+
+    @Test
+    void internalUtilityValueContractsDistinguishIdentityAndMembership() {
+        QuickUnion<String> union = new QuickUnion<>();
+        union.add("alpha");
+        union.add("beta");
+
+        assertThat(union.exists("alpha")).isTrue();
+        assertThat(union.exists("missing")).isFalse();
+        assertThat(union.root("alpha")).isEqualTo("alpha");
+        assertThatThrownBy(() -> union.root("missing"))
+                .isInstanceOf(java.util.NoSuchElementException.class)
+                .hasMessageContaining("missing");
+
+        StaticTopicNameExtractor<String, Integer> extractor = new StaticTopicNameExtractor<>("events");
+        StaticTopicNameExtractor<String, Integer> equivalent = new StaticTopicNameExtractor<>("events");
+        assertThat(extractor.extract("key", 1, null)).isEqualTo("events");
+        assertThat(extractor).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(extractor).isNotEqualTo(new StaticTopicNameExtractor<>("other"))
+                .isNotEqualTo(null)
+                .isNotEqualTo("events");
+        assertThat(extractor).hasToString("StaticTopicNameExtractor(events)");
+    }
+
+    @Test
+    void streamExceptionFamiliesRetainMessagesAndCausesAcrossConstructors() {
+        RuntimeException cause = new RuntimeException("root cause");
+        List<BiFunction<String, Throwable, StreamsException>> withCause = List.of(
+                BrokerNotFoundException::new,
+                InvalidStateStoreException::new,
+                LockException::new,
+                ProcessorStateException::new,
+                TaskAssignmentException::new,
+                TaskIdFormatException::new,
+                TopologyException::new,
+                InvalidStateStorePartitionException::new,
+                StateStoreMigratedException::new,
+                StateStoreNotAvailableException::new,
+                StreamsNotStartedException::new,
+                StreamsRebalancingException::new,
+                StreamsStoppedException::new,
+                TaskMigratedException::new,
+                UnknownStateStoreException::new);
+        List<Function<String, StreamsException>> messageOnly = List.of(
+                BrokerNotFoundException::new,
+                InvalidStateStoreException::new,
+                LockException::new,
+                ProcessorStateException::new,
+                TaskAssignmentException::new,
+                TaskIdFormatException::new,
+                TopologyException::new,
+                InvalidStateStorePartitionException::new,
+                StateStoreMigratedException::new,
+                StateStoreNotAvailableException::new,
+                StreamsNotStartedException::new,
+                StreamsRebalancingException::new,
+                StreamsStoppedException::new,
+                TaskMigratedException::new,
+                UnknownStateStoreException::new);
+
+        assertThat(withCause).allSatisfy(factory -> {
+            StreamsException exception = factory.apply("operation failed", cause);
+            assertThat(exception).hasMessageContaining("operation failed").hasCause(cause);
+        });
+        assertThat(messageOnly).allSatisfy(factory ->
+                assertThat(factory.apply("operation failed")).hasMessageContaining("operation failed"));
+
+        List<Function<Throwable, StreamsException>> causeOnly = List.of(
+                BrokerNotFoundException::new,
+                InvalidStateStoreException::new,
+                LockException::new,
+                ProcessorStateException::new,
+                TaskAssignmentException::new,
+                TaskIdFormatException::new,
+                TopologyException::new);
+        assertThat(causeOnly).allSatisfy(factory -> assertThat(factory.apply(cause)).hasCause(cause));
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InteractiveQueryCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InteractiveQueryCoverageTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.KeyQuery;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.query.WindowKeyQuery;
+import org.apache.kafka.streams.query.WindowRangeQuery;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class InteractiveQueryCoverageTest {
+
+    @Test
+    void positionMaintainsMonotonicIndependentOffsets() {
+        Map<Integer, Long> inputPartitions = new HashMap<>(Map.of(0, 4L));
+        Map<String, Map<Integer, Long>> input = new HashMap<>(Map.of("orders", inputPartitions));
+        Position position = Position.fromMap(input);
+        inputPartitions.put(0, 100L);
+
+        position.withComponent("orders", 0, 3L)
+                .withComponent("orders", 0, 7L)
+                .withComponent("payments", 2, 9L)
+                .merge(Position.fromMap(Map.of("orders", Map.of(0, 6L, 1, 8L))))
+                .merge(null);
+
+        assertThat(position.getTopics()).containsExactlyInAnyOrder("orders", "payments");
+        assertThat(position.getPartitionPositions("orders")).containsExactlyInAnyOrderEntriesOf(
+                Map.of(0, 7L, 1, 8L));
+        assertThat(position.getPartitionPositions("missing")).isEmpty();
+        assertThat(position.copy()).isEqualTo(position).isNotSameAs(position);
+        assertThat(position).isNotEqualTo(Position.emptyPosition()).isNotEqualTo(null);
+        assertThat(position.toString()).contains("orders", "payments");
+        assertThat(position.isEmpty()).isFalse();
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(position::hashCode);
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> position.getTopics().clear());
+    }
+
+    @Test
+    void positionBoundsSnapshotTheirPositionAndUseValueSemantics() {
+        Position source = Position.emptyPosition().withComponent("orders", 0, 12L);
+        PositionBound bound = PositionBound.at(source);
+        source.withComponent("orders", 0, 20L);
+        PositionBound equivalent = PositionBound.at(
+                Position.emptyPosition().withComponent("orders", 0, 12L));
+
+        assertThat(bound.position().getPartitionPositions("orders")).containsEntry(0, 12L);
+        assertThat(bound).isEqualTo(equivalent).isNotEqualTo(PositionBound.unbounded()).isNotEqualTo(null);
+        assertThat(bound.isUnbounded()).isFalse();
+        assertThat(PositionBound.unbounded().isUnbounded()).isTrue();
+        assertThat(bound.toString()).contains("orders", "12");
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(bound::hashCode);
+    }
+
+    @Test
+    void stateQueryRequestRetainsImmutableBuilderChoices() {
+        KeyQuery<String, String> query = KeyQuery.<String, String>withKey("customer-1").skipCache();
+        PositionBound bound = PositionBound.at(Position.emptyPosition().withComponent("orders", 1, 5L));
+        Set<Integer> requestedPartitions = new java.util.HashSet<>(Set.of(1, 2));
+        StateQueryRequest<String> request = StateQueryRequest.inStore("customer-store")
+                .withQuery(query)
+                .withPositionBound(bound)
+                .withPartitions(requestedPartitions)
+                .enableExecutionInfo()
+                .requireActive();
+        requestedPartitions.clear();
+
+        assertThat(request.getStoreName()).isEqualTo("customer-store");
+        assertThat(request.getQuery()).isSameAs(query);
+        assertThat(request.getPositionBound()).isEqualTo(bound);
+        assertThat(request.isAllPartitions()).isFalse();
+        assertThat(request.getPartitions()).containsExactlyInAnyOrder(1, 2);
+        assertThat(request.executionInfoEnabled()).isTrue();
+        assertThat(request.isRequireActive()).isTrue();
+        assertThat(query.getKey()).isEqualTo("customer-1");
+        assertThat(query.isSkipCache()).isTrue();
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> request.getPartitions().clear());
+
+        StateQueryRequest<String> allPartitions = request.withAllPartitions();
+        assertThat(allPartitions.isAllPartitions()).isTrue();
+        assertThatIllegalStateException().isThrownBy(allPartitions::getPartitions);
+        assertThatNullPointerException().isThrownBy(() -> KeyQuery.withKey(null));
+    }
+
+    @Test
+    void stateQueryResultAggregatesPartitionPositionsAndSelectsSingleValue() {
+        QueryResult<String> first = QueryResult.forResult("first");
+        first.setPosition(Position.emptyPosition().withComponent("orders", 0, 3L));
+        first.addExecutionInfo("served from cache");
+        QueryResult<String> empty = QueryResult.forResult(null);
+        empty.setPosition(Position.emptyPosition().withComponent("orders", 1, 4L));
+        StateQueryResult<String> result = new StateQueryResult<>();
+        result.addResult(0, first);
+        result.addResult(1, empty);
+
+        assertThat(result.getOnlyPartitionResult()).isSameAs(first);
+        assertThat(result.getPartitionResults()).containsEntry(0, first).containsEntry(1, empty);
+        assertThat(result.getPosition().getPartitionPositions("orders"))
+                .containsExactlyInAnyOrderEntriesOf(Map.of(0, 3L, 1, 4L));
+        assertThat(first.isSuccess()).isTrue();
+        assertThat(first.isFailure()).isFalse();
+        assertThat(first.getResult()).isEqualTo("first");
+        assertThat(first.getExecutionInfo()).containsExactly("served from cache");
+        assertThat(result.toString()).contains("partitionResults", "first");
+
+        result.addResult(2, QueryResult.forResult("second"));
+        assertThatIllegalArgumentException().isThrownBy(result::getOnlyPartitionResult);
+    }
+
+    @Test
+    void globalAndFailedQueryResultsExposeTheirDiagnostics() {
+        QueryResult<String> global = QueryResult.forResult("global-value");
+        Position globalPosition = Position.emptyPosition().withComponent("global-topic", 0, 15L);
+        global.setPosition(globalPosition);
+        StateQueryResult<String> result = new StateQueryResult<>();
+        result.setGlobalResult(global);
+
+        assertThat(result.getGlobalResult()).isSameAs(global);
+        assertThat(result.getPosition()).isEqualTo(globalPosition);
+
+        QueryResult<String> failure = QueryResult.forFailure(FailureReason.NOT_ACTIVE, "standby replica");
+        failure.addExecutionInfo("partition is not active");
+        failure.setPosition(Position.emptyPosition());
+        assertThat(failure.isFailure()).isTrue();
+        assertThat(failure.isSuccess()).isFalse();
+        assertThat(failure.getFailureReason()).isEqualTo(FailureReason.NOT_ACTIVE);
+        assertThat(failure.getFailureMessage()).isEqualTo("standby replica");
+        assertThat(failure.getExecutionInfo()).containsExactly("partition is not active");
+        assertThat(failure.toString()).contains("NOT_ACTIVE", "standby replica");
+        assertThatIllegalArgumentException().isThrownBy(failure::getResult);
+        assertThatIllegalArgumentException().isThrownBy(global::getFailureReason);
+        assertThatIllegalArgumentException().isThrownBy(global::getFailureMessage);
+    }
+
+    @Test
+    void rangeQueriesPreserveIndependentKeyAndWindowBounds() {
+        RangeQuery<String, Long> bounded = RangeQuery.withRange("a", "z");
+        RangeQuery<String, Long> lowerBounded = RangeQuery.withLowerBound("m");
+        RangeQuery<String, Long> upperBounded = RangeQuery.withUpperBound("n");
+        RangeQuery<String, Long> unbounded = RangeQuery.withNoBounds();
+        WindowRangeQuery<String, Long> keyed = WindowRangeQuery.withKey("account");
+        Instant from = Instant.ofEpochMilli(10L);
+        Instant to = Instant.ofEpochMilli(20L);
+        WindowRangeQuery<String, Long> windowed = WindowRangeQuery.withWindowStartRange(from, to);
+
+        assertThat(bounded.getLowerBound()).contains("a");
+        assertThat(bounded.getUpperBound()).contains("z");
+        assertThat(lowerBounded.getLowerBound()).contains("m");
+        assertThat(lowerBounded.getUpperBound()).isEmpty();
+        assertThat(upperBounded.getLowerBound()).isEmpty();
+        assertThat(upperBounded.getUpperBound()).contains("n");
+        assertThat(unbounded.getLowerBound()).isEmpty();
+        assertThat(unbounded.getUpperBound()).isEmpty();
+        assertThat(keyed.getKey()).contains("account");
+        assertThat(keyed.getTimeFrom()).isEmpty();
+        assertThat(keyed.getTimeTo()).isEmpty();
+        assertThat(windowed.getKey()).isEmpty();
+        assertThat(windowed.getTimeFrom()).contains(from);
+        assertThat(windowed.getTimeTo()).contains(to);
+        assertThat(windowed.toString()).contains(from.toString(), to.toString());
+    }
+
+    @Test
+    void queryFailureFactoriesExplainUnsupportedQueriesAndPositionLag() {
+        RangeQuery<String, String> query = RangeQuery.withNoBounds();
+        StateStore store = Stores.inMemoryKeyValueStore("query-store").get();
+        QueryResult<?> unknown = QueryResult.forUnknownQueryType(query, store);
+        Position current = Position.emptyPosition().withComponent("orders", 2, 10L);
+        PositionBound bound = PositionBound.at(
+                Position.emptyPosition().withComponent("orders", 2, 20L));
+        QueryResult<?> partitionLag = QueryResult.notUpToBound(current, bound, 2);
+        QueryResult<?> uninitialized = QueryResult.notUpToBound(current, bound, null);
+
+        assertThat(unknown.getFailureReason()).isEqualTo(FailureReason.UNKNOWN_QUERY_TYPE);
+        assertThat(unknown.getFailureMessage()).contains("InMemoryKeyValueStore", query.toString());
+        assertThat(partitionLag.getFailureReason()).isEqualTo(FailureReason.NOT_UP_TO_BOUND);
+        assertThat(partitionLag.getFailureMessage()).contains("partition 2", "orders", "10", "20");
+        assertThat(uninitialized.getFailureReason()).isEqualTo(FailureReason.NOT_UP_TO_BOUND);
+        assertThat(uninitialized.getFailureMessage()).contains("not initialized", "orders", "20");
+    }
+
+    @Test
+    void windowKeyQueryAndTimestampedValueExposeConfiguredValues() {
+        Instant from = Instant.ofEpochMilli(10L);
+        Instant to = Instant.ofEpochMilli(20L);
+        WindowKeyQuery<String, Long> query =
+                WindowKeyQuery.withKeyAndWindowStartRange("account", from, to);
+        ValueAndTimestamp<String> nullable = ValueAndTimestamp.makeAllowNullable(null, 42L);
+        ValueAndTimestamp<String> value = ValueAndTimestamp.make("balance", 43L);
+        ValueAndTimestamp<String> equivalent = ValueAndTimestamp.make("balance", 43L);
+
+        assertThat(query.getKey()).isEqualTo("account");
+        // Kafka Streams 3.6 exposes these endpoints in reverse due to its constructor ordering.
+        assertThat(query.getTimeFrom()).contains(to);
+        assertThat(query.getTimeTo()).contains(from);
+        assertThat(query.toString()).contains("account", from.toString(), to.toString());
+        assertThat(nullable.value()).isNull();
+        assertThat(nullable.toString()).isEqualTo("<null,42>");
+        assertThat(ValueAndTimestamp.make(null, 1L)).isNull();
+        assertThat(ValueAndTimestamp.<String>getValueOrNull(null)).isNull();
+        assertThat(ValueAndTimestamp.getValueOrNull(value)).isEqualTo("balance");
+        assertThat(value.timestamp()).isEqualTo(43L);
+        assertThat(value).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(value).isNotEqualTo(nullable).isNotEqualTo(null);
+        assertThat(value.toString()).isEqualTo("<balance,43>");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsValueObjectsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsValueObjectsCoverageTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TaskMetadata;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.QueryableStoreType;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class KafkaStreamsValueObjectsCoverageTest {
+
+    @Test
+    void storeQueryParametersPreserveSettingsAcrossImmutableUpdates() {
+        QueryableStoreType<ReadOnlyKeyValueStore<String, Long>> type = QueryableStoreTypes.keyValueStore();
+        StoreQueryParameters<ReadOnlyKeyValueStore<String, Long>> initial =
+                StoreQueryParameters.fromNameAndType("counts", type);
+        StoreQueryParameters<ReadOnlyKeyValueStore<String, Long>> configured =
+                initial.withPartition(3).enableStaleStores();
+        StoreQueryParameters<ReadOnlyKeyValueStore<String, Long>> equivalent =
+                StoreQueryParameters.fromNameAndType("counts", type).withPartition(3).enableStaleStores();
+
+        assertThat(initial.storeName()).isEqualTo("counts");
+        assertThat(initial.queryableStoreType()).isSameAs(type);
+        assertThat(initial.partition()).isNull();
+        assertThat(initial.staleStoresEnabled()).isFalse();
+        assertThat(configured.partition()).isEqualTo(3);
+        assertThat(configured.staleStoresEnabled()).isTrue();
+        assertThat(configured).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(configured).isNotEqualTo(initial).isNotEqualTo("counts");
+        assertThat(configured.toString()).contains("partition=3", "staleStores=true", "storeName=counts");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void keyQueryMetadataExposesActiveAndStandbyLocations() {
+        HostInfo active = new HostInfo("active.example", 9092);
+        HostInfo standby = new HostInfo("standby.example", 9093);
+        KeyQueryMetadata metadata = new KeyQueryMetadata(active, Set.of(standby), 4);
+        KeyQueryMetadata equivalent = new KeyQueryMetadata(active, Set.of(standby), 4);
+
+        assertThat(metadata.activeHost()).isEqualTo(active);
+        assertThat(metadata.getActiveHost()).isEqualTo(active);
+        assertThat(metadata.standbyHosts()).containsExactly(standby);
+        assertThat(metadata.getStandbyHosts()).containsExactly(standby);
+        assertThat(metadata.partition()).isEqualTo(4);
+        assertThat(metadata.getPartition()).isEqualTo(4);
+        assertThat(metadata).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(metadata).isNotEqualTo(KeyQueryMetadata.NOT_AVAILABLE).isNotEqualTo(null);
+        assertThat(metadata.toString()).contains("active.example", "standby.example", "partition=4");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void sessionWindowsValidateAndRetainGapAndGrace() {
+        SessionWindows noGrace = SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5));
+        SessionWindows withGrace = SessionWindows.ofInactivityGapAndGrace(
+                Duration.ofSeconds(5), Duration.ofSeconds(2));
+        SessionWindows legacy = SessionWindows.with(Duration.ofSeconds(5)).grace(Duration.ofSeconds(2));
+
+        assertThat(noGrace.inactivityGap()).isEqualTo(5_000L);
+        assertThat(noGrace.gracePeriodMs()).isZero();
+        assertThat(withGrace.inactivityGap()).isEqualTo(5_000L);
+        assertThat(withGrace.gracePeriodMs()).isEqualTo(2_000L);
+        assertThat(withGrace).isEqualTo(legacy).hasSameHashCodeAs(legacy);
+        assertThat(withGrace).isNotEqualTo(noGrace).isNotEqualTo(null);
+        assertThat(withGrace.toString()).contains("gapMs=5000", "graceMs=2000");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SessionWindows.ofInactivityGapWithNoGrace(Duration.ZERO));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SessionWindows.ofInactivityGapAndGrace(
+                        Duration.ofSeconds(1), Duration.ofMillis(-1)));
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> noGrace.grace(Duration.ofSeconds(1)));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void slidingWindowsValidateAndRetainDifferenceAndGrace() {
+        SlidingWindows noGrace = SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5));
+        SlidingWindows withGrace = SlidingWindows.ofTimeDifferenceAndGrace(
+                Duration.ofSeconds(5), Duration.ofSeconds(2));
+        SlidingWindows legacy = SlidingWindows.withTimeDifferenceAndGrace(
+                Duration.ofSeconds(5), Duration.ofSeconds(2));
+
+        assertThat(noGrace.timeDifferenceMs()).isEqualTo(5_000L);
+        assertThat(noGrace.gracePeriodMs()).isZero();
+        assertThat(withGrace.timeDifferenceMs()).isEqualTo(5_000L);
+        assertThat(withGrace.gracePeriodMs()).isEqualTo(2_000L);
+        assertThat(withGrace).isEqualTo(legacy).hasSameHashCodeAs(legacy);
+        assertThat(withGrace).isNotEqualTo(noGrace).isNotEqualTo(null);
+        assertThat(withGrace.toString()).contains("sizeMs=5000", "graceMs=2000");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(-1)));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> SlidingWindows.ofTimeDifferenceAndGrace(
+                        Duration.ZERO, Duration.ofMillis(-1)));
+    }
+
+    @Test
+    void unlimitedWindowsCreateOnlyTheirLandmarkWindow() {
+        UnlimitedWindows initial = UnlimitedWindows.of();
+        UnlimitedWindows shifted = initial.startOn(Instant.ofEpochMilli(100));
+        UnlimitedWindows equivalent = UnlimitedWindows.of().startOn(Instant.ofEpochMilli(100));
+
+        assertThat(initial.windowsFor(0)).containsOnlyKeys(0L);
+        assertThat(shifted.windowsFor(99)).isEmpty();
+        assertThat(shifted.windowsFor(100)).containsOnlyKeys(100L);
+        assertThat(shifted.size()).isEqualTo(Long.MAX_VALUE);
+        assertThat(shifted.gracePeriodMs()).isZero();
+        assertThat(shifted).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(shifted).isNotEqualTo(initial).isNotEqualTo(null);
+        assertThat(shifted.toString()).contains("startMs=100");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> initial.startOn(Instant.ofEpochMilli(-1)));
+    }
+
+    @Test
+    void repartitionConfigurationProducesNamedTopologyNodes() {
+        Serde<String> stringSerde = Serdes.String();
+        Serde<Long> longSerde = Serdes.Long();
+        StreamPartitioner<String, Long> partitioner =
+                (topic, key, value, partitions) -> 0;
+        Repartitioned<String, Long> repartitioned = Repartitioned
+                .with(stringSerde, longSerde)
+                .withName("orders")
+                .withNumberOfPartitions(2)
+                .withKeySerde(stringSerde)
+                .withValueSerde(longSerde)
+                .withStreamPartitioner(partitioner);
+
+        assertThat(Repartitioned.<String, Long>as("named")).isNotNull();
+        assertThat(Repartitioned.<String, Long>numberOfPartitions(2)).isNotNull();
+        assertThat(Repartitioned.<String, Long>streamPartitioner(partitioner)).isNotNull();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.<String, Long>stream("input").repartition(repartitioned).to("output");
+        Topology topology = builder.build();
+
+        assertThat(topology.describe().toString())
+                .contains("orders-repartition-source", "orders-repartition-sink", "output");
+    }
+
+    @Test
+    void legacyForwardingOptionsRepresentDestinationAndTimestamp() {
+        To child = To.child("aggregate").withTimestamp(42L);
+        To equivalent = To.child("aggregate").withTimestamp(42L);
+
+        assertThat(child).isEqualTo(equivalent).isNotEqualTo(To.all()).isNotEqualTo(null);
+        assertThat(child.toString()).contains("aggregate", "timestamp=42");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(child::hashCode);
+    }
+
+    @Test
+    void versionedRecordRequiresAValueAndUsesValueSemantics() {
+        VersionedRecord<String> record = new VersionedRecord<>("value", 123L);
+        VersionedRecord<String> equivalent = new VersionedRecord<>("value", 123L);
+
+        assertThat(record.value()).isEqualTo("value");
+        assertThat(record.timestamp()).isEqualTo(123L);
+        assertThat(record).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(record).isNotEqualTo(new VersionedRecord<>("other", 123L)).isNotEqualTo(null);
+        assertThat(record.toString()).isEqualTo("<value,123>");
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new VersionedRecord<>(null, 123L));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void taskMetadataExposesAnImmutableTaskSnapshot() {
+        TopicPartition partition = new TopicPartition("input", 2);
+        TaskMetadata metadata = new TaskMetadata(
+                "1_2", Set.of(partition), Map.of(partition, 10L), Map.of(partition, 15L), Optional.of(99L));
+        TaskMetadata equivalent = new TaskMetadata(
+                "1_2", Set.of(partition), Map.of(partition, 11L), Map.of(partition, 16L), Optional.empty());
+
+        assertThat(metadata.taskId()).isEqualTo("1_2");
+        assertThat(metadata.topicPartitions()).containsExactly(partition);
+        assertThat(metadata.committedOffsets()).containsEntry(partition, 10L);
+        assertThat(metadata.endOffsets()).containsEntry(partition, 15L);
+        assertThat(metadata.timeCurrentIdlingStarted()).contains(99L);
+        assertThat(metadata).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(metadata).isNotEqualTo(null);
+        assertThat(metadata.toString()).contains("taskId=1_2", "input-2", "Optional[99]");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> metadata.topicPartitions().clear());
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/LegacyMetadataAndSuppressionCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/LegacyMetadataAndSuppressionCoverageTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.suppress.BufferConfigInternal;
+import org.apache.kafka.streams.kstream.internals.suppress.EagerBufferConfigImpl;
+import org.apache.kafka.streams.kstream.internals.suppress.FinalResultsSuppressionBuilder;
+import org.apache.kafka.streams.kstream.internals.suppress.StrictBufferConfigImpl;
+import org.apache.kafka.streams.kstream.internals.suppress.SuppressedInternal;
+import org.apache.kafka.streams.processor.TaskMetadata;
+import org.apache.kafka.streams.processor.ThreadMetadata;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class LegacyMetadataAndSuppressionCoverageTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void legacyThreadMetadataExposesAnImmutableRuntimeSnapshot() {
+        TopicPartition partition = new TopicPartition("orders", 1);
+        TaskMetadata activeTask = new TaskMetadata(
+                "0_1", Set.of(partition), Map.of(partition, 4L), Map.of(partition, 9L), Optional.empty());
+        ThreadMetadata metadata = new ThreadMetadata(
+                "stream-thread-1",
+                "RUNNING",
+                "consumer-1",
+                "restore-1",
+                Set.of("producer-1"),
+                "admin-1",
+                Set.of(activeTask),
+                Set.of());
+        ThreadMetadata equivalent = new ThreadMetadata(
+                "stream-thread-1",
+                "RUNNING",
+                "consumer-1",
+                "restore-1",
+                Set.of("producer-1"),
+                "admin-1",
+                Set.of(activeTask),
+                Set.of());
+
+        assertThat(metadata.threadName()).isEqualTo("stream-thread-1");
+        assertThat(metadata.threadState()).isEqualTo("RUNNING");
+        assertThat(metadata.consumerClientId()).isEqualTo("consumer-1");
+        assertThat(metadata.restoreConsumerClientId()).isEqualTo("restore-1");
+        assertThat(metadata.producerClientIds()).containsExactly("producer-1");
+        assertThat(metadata.adminClientId()).isEqualTo("admin-1");
+        assertThat(metadata.activeTasks()).containsExactly(activeTask);
+        assertThat(metadata.standbyTasks()).isEmpty();
+        assertThat(metadata).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(metadata).isNotEqualTo(null).isNotEqualTo("stream-thread-1");
+        assertThat(metadata.toString()).contains("stream-thread-1", "RUNNING", "consumer-1", "0_1");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> metadata.activeTasks().clear());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void legacyStreamsMetadataDescribesActiveAndStandbyResources() {
+        HostInfo host = new HostInfo("streams.example", 8080);
+        TopicPartition activePartition = new TopicPartition("orders", 0);
+        TopicPartition standbyPartition = new TopicPartition("orders", 1);
+        StreamsMetadata metadata = new StreamsMetadata(
+                host,
+                Set.of("orders-store"),
+                Set.of(activePartition),
+                Set.of("standby-store"),
+                Set.of(standbyPartition));
+        StreamsMetadata equivalent = new StreamsMetadata(
+                host,
+                Set.of("orders-store"),
+                Set.of(activePartition),
+                Set.of("standby-store"),
+                Set.of(standbyPartition));
+
+        assertThat(metadata.hostInfo()).isEqualTo(host);
+        assertThat(metadata.host()).isEqualTo("streams.example");
+        assertThat(metadata.port()).isEqualTo(8080);
+        assertThat(metadata.stateStoreNames()).containsExactly("orders-store");
+        assertThat(metadata.topicPartitions()).containsExactly(activePartition);
+        assertThat(metadata.standbyStateStoreNames()).containsExactly("standby-store");
+        assertThat(metadata.standbyTopicPartitions()).containsExactly(standbyPartition);
+        assertThat(metadata).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(metadata).isNotEqualTo(StreamsMetadata.NOT_AVAILABLE).isNotEqualTo(null);
+        assertThat(metadata.toString()).contains("streams.example", "orders-store", "standby-store");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> metadata.topicPartitions().clear());
+    }
+
+    @Test
+    void bufferConfigurationsPreserveLimitsStrategiesAndLogging() {
+        Suppressed.EagerBufferConfig eagerConfig = Suppressed.BufferConfig.maxRecords(10L)
+                .withMaxBytes(1_024L)
+                .withLoggingEnabled(Map.of("cleanup.policy", "compact"));
+        EagerBufferConfigImpl eager = (EagerBufferConfigImpl) eagerConfig;
+        EagerBufferConfigImpl equivalentEager = new EagerBufferConfigImpl(
+                10L, 1_024L, Map.of("cleanup.policy", "compact"));
+
+        assertThat(eager.maxRecords()).isEqualTo(10L);
+        assertThat(eager.maxBytes()).isEqualTo(1_024L);
+        assertThat(eager.bufferFullStrategy().toString()).isEqualTo("EMIT");
+        assertThat(eager.isLoggingEnabled()).isTrue();
+        assertThat(eager.getLogConfig()).containsEntry("cleanup.policy", "compact");
+        assertThat(eager).isEqualTo(equivalentEager).hasSameHashCodeAs(equivalentEager);
+        assertThat(eager).isNotEqualTo(null).isNotEqualTo("buffer");
+        assertThat(eager.toString()).contains("maxRecords=10", "maxBytes=1024", "cleanup.policy");
+
+        EagerBufferConfigImpl disabled = (EagerBufferConfigImpl) eager.withLoggingDisabled();
+        assertThat(disabled.isLoggingEnabled()).isFalse();
+        assertThat(disabled.getLogConfig()).isEmpty();
+
+        BufferConfigInternal<?> strict = (BufferConfigInternal<?>) eager.shutDownWhenFull();
+        BufferConfigInternal<?> unbounded = (BufferConfigInternal<?>) eager.withNoBound();
+        BufferConfigInternal<?> early = (BufferConfigInternal<?>) strict.emitEarlyWhenFull();
+        assertThat(strict.maxRecords()).isEqualTo(10L);
+        assertThat(strict.maxBytes()).isEqualTo(1_024L);
+        assertThat(strict.bufferFullStrategy().toString()).isEqualTo("SHUT_DOWN");
+        assertThat(unbounded.maxRecords()).isEqualTo(Long.MAX_VALUE);
+        assertThat(unbounded.maxBytes()).isEqualTo(Long.MAX_VALUE);
+        assertThat(early.bufferFullStrategy().toString()).isEqualTo("EMIT");
+    }
+
+    @Test
+    void suppressionBuildersRetainTimingNamingAndBufferContracts() {
+        StrictBufferConfigImpl buffer = (StrictBufferConfigImpl) Suppressed.BufferConfig.unbounded()
+                .withMaxRecords(50L)
+                .withMaxBytes(2_048L)
+                .withLoggingDisabled();
+        StrictBufferConfigImpl equivalentBuffer = (StrictBufferConfigImpl) Suppressed.BufferConfig.unbounded()
+                .withMaxRecords(50L)
+                .withMaxBytes(2_048L)
+                .withLoggingDisabled();
+
+        assertThat(buffer.maxRecords()).isEqualTo(50L);
+        assertThat(buffer.maxBytes()).isEqualTo(2_048L);
+        assertThat(buffer.bufferFullStrategy().toString()).isEqualTo("SHUT_DOWN");
+        assertThat(buffer.isLoggingEnabled()).isFalse();
+        assertThat(buffer.getLogConfig()).isEmpty();
+        assertThat(buffer).isEqualTo(equivalentBuffer).hasSameHashCodeAs(equivalentBuffer);
+        assertThat(buffer).isNotEqualTo(null).isNotEqualTo("buffer");
+        assertThat(buffer.toString()).contains("maxKeys=50", "maxBytes=2048", "SHUT_DOWN");
+
+        SuppressedInternal<String> timed = (SuppressedInternal<String>) Suppressed.<String>untilTimeLimit(
+                Duration.ofSeconds(3), buffer).withName("quiet-period");
+        SuppressedInternal<String> equivalentTimed = (SuppressedInternal<String>) Suppressed.<String>untilTimeLimit(
+                Duration.ofSeconds(3), equivalentBuffer).withName("quiet-period");
+        assertThat(timed.name()).isEqualTo("quiet-period");
+        assertThat(timed.bufferConfig()).isEqualTo(buffer);
+        assertThat(timed).isEqualTo(equivalentTimed).hasSameHashCodeAs(equivalentTimed);
+        assertThat(timed).isNotEqualTo(null).isNotEqualTo("quiet-period");
+        assertThat(timed.toString()).contains("quiet-period", "PT3S", "maxKeys=50");
+
+        FinalResultsSuppressionBuilder<Windowed> finalResults =
+                (FinalResultsSuppressionBuilder<Windowed>) Suppressed.untilWindowCloses(buffer)
+                        .withName("window-final");
+        SuppressedInternal<Windowed> built = finalResults.buildFinalResultsSuppression(Duration.ofSeconds(1));
+        assertThat(finalResults.name()).isEqualTo("window-final");
+        assertThat(finalResults.toString()).contains("window-final", "maxKeys=50");
+        assertThat(built.name()).isEqualTo("window-final");
+        assertThat(built.bufferConfig()).isEqualTo(buffer);
+        assertThat(built.toString()).contains("PT1S", "safeToDropTombstones=true");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/Murmur3CoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/Murmur3CoverageTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.streams.state.internals.Murmur3;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Murmur3CoverageTest {
+
+    @Test
+    void producesCanonicalMurmur3Vectors() {
+        byte[] hello = "hello".getBytes(StandardCharsets.UTF_8);
+
+        assertThat(Murmur3.hash32(hello, hello.length, 0)).isEqualTo(613_153_351);
+        assertThat(Murmur3.hash128(hello, 0, hello.length, 0))
+                .containsExactly(-3_758_069_500_696_749_310L, 6_565_844_092_913_065_241L);
+    }
+
+    @Test
+    void arrayOverloadsRespectOffsetsLengthsAndSeeds() {
+        byte[] data = new byte[34];
+        for (int index = 0; index < data.length; index++) {
+            data[index] = (byte) (index * 7 + 3);
+        }
+
+        for (int length = 0; length <= 32; length++) {
+            byte[] slice = Arrays.copyOfRange(data, 1, length + 1);
+
+            assertThat(Murmur3.hash32(data, 1, length, Murmur3.DEFAULT_SEED))
+                    .isEqualTo(Murmur3.hash32(slice));
+            assertThat(Murmur3.hash32(slice, length)).isEqualTo(Murmur3.hash32(slice));
+            assertThat(Murmur3.hash32(slice, length, 17))
+                    .isEqualTo(Murmur3.hash32(slice, 0, length, 17));
+            assertThat(Murmur3.hash64(data, 1, length))
+                    .isEqualTo(Murmur3.hash64(slice));
+            assertThat(Murmur3.hash64(data, 1, length, 17))
+                    .isNotEqualTo(Murmur3.hash64(data, 1, length, 18));
+            assertThat(Murmur3.hash128(data, 1, length, 17))
+                    .containsExactly(Murmur3.hash128(slice, 0, length, 17));
+        }
+    }
+
+    @Test
+    void incrementalHashMatchesOneShotHashAcrossEverySplit() {
+        byte[] data = "incremental hashing must preserve partial words"
+                .getBytes(StandardCharsets.UTF_8);
+
+        for (int split = 0; split <= data.length; split++) {
+            Murmur3.IncrementalHash32 incremental = new Murmur3.IncrementalHash32();
+            incremental.start(29);
+            incremental.add(data, 0, split);
+            incremental.add(data, split, data.length - split);
+
+            assertThat(incremental.end())
+                    .as("split at byte %s", split)
+                    .isEqualTo(Murmur3.hash32(data, 0, data.length, 29));
+        }
+    }
+
+    @Test
+    void primitiveOverloadsUseStableTypeSpecificEncodings() {
+        assertThat(Murmur3.hash32(42L)).isEqualTo(Murmur3.hash32(42L, Murmur3.DEFAULT_SEED));
+        assertThat(Murmur3.hash32(42L, 84L))
+                .isEqualTo(Murmur3.hash32(42L, 84L, Murmur3.DEFAULT_SEED));
+        assertThat(Murmur3.hash64((short) 42)).isEqualTo(5_976_052_811_867_784_168L);
+        assertThat(Murmur3.hash64(42)).isEqualTo(8_831_750_612_535_747_064L);
+        assertThat(Murmur3.hash64(42L)).isEqualTo(-9_051_690_767_330_425_106L);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/SerializationContractsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/SerializationContractsCoverageTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SerializationContractsCoverageTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void taskIdsRoundTripAcrossTextAndLegacyProtocolRepresentations() throws Exception {
+        TaskId unnamed = new TaskId(3, 7);
+        TaskId named = new TaskId(3, 7, "orders");
+
+        assertThat(TaskId.parse(unnamed.toString())).isEqualTo(unnamed);
+        assertThat(TaskId.parse(named.toString())).isEqualTo(named);
+        assertThat(named.subtopology()).isEqualTo(3);
+        assertThat(named.partition()).isEqualTo(7);
+        assertThat(named.topologyName()).isEqualTo("orders");
+        assertThat(new TaskId(3, 7, "").topologyName()).isNull();
+        assertThatThrownBy(() -> TaskId.parse("not-a-task"))
+                .isInstanceOf(TaskIdFormatException.class);
+
+        assertThat(new TaskId(2, 9)).isLessThan(unnamed);
+        assertThat(new TaskId(3, 6)).isLessThan(unnamed);
+        assertThat(new TaskId(3, 8)).isGreaterThan(unnamed);
+        assertThat(new TaskId(3, 7, "alpha")).isLessThan(named);
+        assertThatThrownBy(() -> named.compareTo(unnamed))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("namedTopology");
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        unnamed.writeTo(new DataOutputStream(bytes), 9);
+        TaskId dataRoundTrip = TaskId.readFrom(
+                new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())), 9);
+        assertThat(dataRoundTrip).isEqualTo(unnamed);
+
+        ByteBuffer buffer = ByteBuffer.allocate(128);
+        named.writeTo(buffer, 10);
+        buffer.flip();
+        assertThat(TaskId.readFrom(buffer, 10)).isEqualTo(named);
+        assertThatThrownBy(() -> named.writeTo(ByteBuffer.allocate(32), 9))
+                .isInstanceOf(TaskAssignmentException.class)
+                .hasMessageContaining("protocol version 9");
+    }
+
+    @Test
+    void timeWindowedSerdeRoundTripsKeysAndEnforcesConfigurationSources() {
+        Windowed<String> value = new Windowed<>("customer-7", new TimeWindow(100L, 125L));
+        TimeWindowedSerializer<String> serializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        TimeWindowedDeserializer<String> deserializer =
+                new TimeWindowedDeserializer<>(Serdes.String().deserializer(), 25L);
+
+        byte[] serialized = serializer.serialize("events", value);
+        Windowed<String> restored = deserializer.deserialize("events", serialized);
+        assertThat(restored.key()).isEqualTo("customer-7");
+        assertThat(restored.window().start()).isEqualTo(100L);
+        assertThat(restored.window().end()).isEqualTo(125L);
+        assertThat(serializer.serializeBaseKey("events", value))
+                .isEqualTo(Serdes.String().serializer().serialize("events", "customer-7"));
+        assertThat(serializer.serialize("events", null)).isNull();
+        assertThat(deserializer.deserialize("events", null)).isNull();
+        assertThat(deserializer.deserialize("events", new byte[0])).isNull();
+        assertThat(deserializer.getWindowSize()).isEqualTo(25L);
+
+        Map<String, Object> config = Map.of(
+                StreamsConfig.WINDOW_SIZE_MS_CONFIG, "25",
+                StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.StringSerde.class.getName());
+        TimeWindowedSerializer<String> configuredSerializer = new TimeWindowedSerializer<>();
+        configuredSerializer.configure(config, true);
+        TimeWindowedDeserializer<String> configuredDeserializer = new TimeWindowedDeserializer<>();
+        configuredDeserializer.configure(config, true);
+        assertThat(configuredDeserializer.deserialize(
+                "events", configuredSerializer.serialize("events", value))).isEqualTo(value);
+
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new TimeWindowedSerializer<>().configure(Map.of(), true));
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new TimeWindowedDeserializer<>().configure(Map.of(), true));
+        assertThatIllegalArgumentException().isThrownBy(() -> deserializer.configure(
+                Map.of(StreamsConfig.WINDOW_SIZE_MS_CONFIG, 25L), true));
+        assertThatThrownBy(() -> new TimeWindowedSerializer<>().configure(
+                Map.of(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, "missing.Serde"), true))
+                .isInstanceOf(ConfigException.class);
+        assertThatNullPointerException().isThrownBy(
+                () -> new TimeWindowedSerializer<String>().serialize("events", value));
+        assertThatNullPointerException().isThrownBy(
+                () -> new TimeWindowedDeserializer<String>(null, 25L).deserialize("events", serialized));
+
+        serializer.close();
+        deserializer.close();
+        configuredSerializer.close();
+        configuredDeserializer.close();
+    }
+
+    @Test
+    void sessionWindowedSerdePreservesBothInclusiveBoundaries() {
+        Windowed<String> value = new Windowed<>("session", new SessionWindow(40L, 75L));
+        SessionWindowedSerializer<String> serializer =
+                new SessionWindowedSerializer<>(Serdes.String().serializer());
+        SessionWindowedDeserializer<String> deserializer =
+                new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+
+        byte[] serialized = serializer.serialize("sessions", value);
+        assertThat(deserializer.deserialize("sessions", serialized)).isEqualTo(value);
+        assertThat(serializer.serializeBaseKey("sessions", value))
+                .isEqualTo(Serdes.String().serializer().serialize("sessions", "session"));
+        assertThat(serializer.serialize("sessions", null)).isNull();
+        assertThat(deserializer.deserialize("sessions", new byte[0])).isNull();
+
+        Map<String, Object> config = Map.of(
+                StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.StringSerde.class.getName());
+        SessionWindowedSerializer<String> configuredSerializer = new SessionWindowedSerializer<>();
+        SessionWindowedDeserializer<String> configuredDeserializer = new SessionWindowedDeserializer<>();
+        configuredSerializer.configure(config, true);
+        configuredDeserializer.configure(config, true);
+        assertThat(configuredDeserializer.deserialize(
+                "sessions", configuredSerializer.serialize("sessions", value))).isEqualTo(value);
+
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new SessionWindowedSerializer<>().configure(Map.of(), true));
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new SessionWindowedDeserializer<>().configure(Map.of(), true));
+        assertThatNullPointerException().isThrownBy(
+                () -> new SessionWindowedSerializer<String>().serialize("sessions", value));
+        assertThatNullPointerException().isThrownBy(
+                () -> new SessionWindowedDeserializer<String>().deserialize("sessions", serialized));
+
+        serializer.close();
+        deserializer.close();
+        configuredSerializer.close();
+        configuredDeserializer.close();
+    }
+
+    @Test
+    void serdeFactoriesAndStateSerdesExposeReliableTypedRoundTrips() {
+        Serde<Windowed<String>> timeSerde = WindowedSerdes.timeWindowedSerdeFrom(String.class, 10L);
+        Windowed<String> timeValue = new Windowed<>("key", new TimeWindow(20L, 30L));
+        assertThat(timeSerde.deserializer().deserialize(
+                "time", timeSerde.serializer().serialize("time", timeValue))).isEqualTo(timeValue);
+
+        Serde<Windowed<String>> sessionSerde = WindowedSerdes.sessionWindowedSerdeFrom(String.class);
+        Windowed<String> sessionValue = new Windowed<>("key", new SessionWindow(20L, 30L));
+        assertThat(sessionSerde.deserializer().deserialize(
+                "session", sessionSerde.serializer().serialize("session", sessionValue))).isEqualTo(sessionValue);
+
+        StateSerdes<String, Long> stateSerdes =
+                StateSerdes.withBuiltinTypes("store-changelog", String.class, Long.class);
+        assertThat(stateSerdes.topic()).isEqualTo("store-changelog");
+        assertThat(stateSerdes.keySerde()).isNotNull();
+        assertThat(stateSerdes.valueSerde()).isNotNull();
+        assertThat(stateSerdes.keySerializer()).isNotNull();
+        assertThat(stateSerdes.keyDeserializer()).isNotNull();
+        assertThat(stateSerdes.valueSerializer()).isNotNull();
+        assertThat(stateSerdes.valueDeserializer()).isNotNull();
+        assertThat(stateSerdes.keyFrom(stateSerdes.rawKey("account"))).isEqualTo("account");
+        assertThat(stateSerdes.valueFrom(stateSerdes.rawValue(42L))).isEqualTo(42L);
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        StateSerdes raw = stateSerdes;
+        assertThatThrownBy(() -> raw.rawKey(12L))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("actual key type", Long.class.getName());
+        assertThatThrownBy(() -> raw.rawValue("wrong"))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("actual value type", String.class.getName());
+        assertThatNullPointerException().isThrownBy(
+                () -> new StateSerdes<>(null, Serdes.String(), Serdes.Long()));
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/SubscriptionProtocolCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/SubscriptionProtocolCoverageTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.ClientTag;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.PartitionToOffsetSum;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.TaskId;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData.TaskOffsetSum;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionProtocolCoverageTest {
+
+    @Test
+    void legacySubscriptionRoundTripsTaskAssignments() {
+        TaskId previous = new TaskId().setTopicGroupId(3).setPartition(4);
+        TaskId standby = new TaskId().setTopicGroupId(5).setPartition(6);
+        SubscriptionInfoData original = new SubscriptionInfoData()
+                .setVersion(6)
+                .setLatestSupportedVersion(11)
+                .setProcessId(new Uuid(1L, 2L))
+                .setPrevTasks(List.of(previous))
+                .setStandbyTasks(List.of(standby))
+                .setUserEndPoint("host:9092".getBytes(StandardCharsets.UTF_8));
+
+        SubscriptionInfoData decoded = roundTrip(original, (short) 6);
+
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.hashCode()).isEqualTo(original.hashCode());
+        assertThat(decoded.prevTasks()).containsExactly(previous);
+        assertThat(decoded.standbyTasks()).containsExactly(standby);
+        assertThat(decoded.userEndPoint()).asString(StandardCharsets.UTF_8).isEqualTo("host:9092");
+        assertThat(decoded.toString()).contains("version=6", "topicGroupId=3", "partition=6");
+        assertTaskIdContract(previous, 3, 4);
+        assertTaskIdContract(standby, 5, 6);
+    }
+
+    @Test
+    void currentSubscriptionRoundTripsOffsetsTagsAndVersionedFields() {
+        TaskOffsetSum taskOffset = new TaskOffsetSum()
+                .setTopicGroupId(8)
+                .setPartition(9)
+                .setOffsetSum(5678L)
+                .setNamedTopology("payments");
+        ClientTag clientTag = new ClientTag()
+                .setKey("zone".getBytes(StandardCharsets.UTF_8))
+                .setValue("west".getBytes(StandardCharsets.UTF_8));
+        SubscriptionInfoData original = new SubscriptionInfoData()
+                .setVersion(11)
+                .setLatestSupportedVersion(11)
+                .setProcessId(new Uuid(10L, 20L))
+                .setUserEndPoint("worker:9092".getBytes(StandardCharsets.UTF_8))
+                .setTaskOffsetSums(List.of(taskOffset))
+                .setUniqueField((byte) 12)
+                .setErrorCode(13)
+                .setClientTags(List.of(clientTag));
+
+        SubscriptionInfoData decoded = roundTrip(original, (short) 11);
+        SubscriptionInfoData duplicate = decoded.duplicate();
+
+        assertThat(decoded).isEqualTo(original);
+        assertThat(duplicate).isEqualTo(decoded).isNotSameAs(decoded);
+        assertThat(duplicate.taskOffsetSums().get(0)).isNotSameAs(decoded.taskOffsetSums().get(0));
+        assertThat(decoded.apiKey()).isEqualTo((short) -1);
+        assertThat(decoded.lowestSupportedVersion()).isEqualTo((short) 1);
+        assertThat(decoded.highestSupportedVersion()).isEqualTo((short) 11);
+        assertThat(decoded.uniqueField()).isEqualTo((byte) 12);
+        assertThat(decoded.errorCode()).isEqualTo(13);
+        assertThat(decoded.unknownTaggedFields()).isEmpty();
+        assertTaskOffsetContract(decoded.taskOffsetSums().get(0));
+        assertClientTagContract(decoded.clientTags().get(0));
+    }
+
+    @Test
+    void offsetMapSubscriptionRoundTripsPartitionOffsets() {
+        PartitionToOffsetSum partitionOffset = new PartitionToOffsetSum()
+                .setPartition(7)
+                .setOffsetSum(1234L);
+        TaskOffsetSum taskOffset = new TaskOffsetSum()
+                .setTopicGroupId(8)
+                .setPartitionToOffsetSum(List.of(partitionOffset));
+        SubscriptionInfoData original = new SubscriptionInfoData()
+                .setVersion(9)
+                .setLatestSupportedVersion(11)
+                .setProcessId(new Uuid(30L, 40L))
+                .setTaskOffsetSums(List.of(taskOffset))
+                .setUniqueField((byte) 14)
+                .setErrorCode(15);
+
+        SubscriptionInfoData decoded = roundTrip(original, (short) 9);
+        PartitionToOffsetSum decodedOffset = decoded.taskOffsetSums().get(0).partitionToOffsetSum().get(0);
+
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decodedOffset.lowestSupportedVersion()).isEqualTo((short) 7);
+        assertThat(decodedOffset.highestSupportedVersion()).isEqualTo((short) 9);
+        assertThat(decodedOffset.partition()).isEqualTo(7);
+        assertThat(decodedOffset.offsetSum()).isEqualTo(1234L);
+        assertThat(decodedOffset.unknownTaggedFields()).isEmpty();
+        assertThat(decodedOffset.duplicate()).isEqualTo(decodedOffset).isNotSameAs(decodedOffset);
+        assertThat(decodedOffset.hashCode()).isEqualTo(decodedOffset.duplicate().hashCode());
+        assertThat(decodedOffset.toString()).contains("partition=7", "offsetSum=1234");
+    }
+
+    private static SubscriptionInfoData roundTrip(SubscriptionInfoData data, short version) {
+        ByteBuffer serialized = MessageUtil.toByteBuffer(data, version);
+        return new SubscriptionInfoData(new ByteBufferAccessor(serialized), version);
+    }
+
+    private static void assertTaskIdContract(TaskId task, int group, int partition) {
+        TaskId duplicate = task.duplicate();
+        assertThat(task.lowestSupportedVersion()).isEqualTo((short) 1);
+        assertThat(task.highestSupportedVersion()).isEqualTo((short) 6);
+        assertThat(task.topicGroupId()).isEqualTo(group);
+        assertThat(task.partition()).isEqualTo(partition);
+        assertThat(task.unknownTaggedFields()).isEmpty();
+        assertThat(duplicate).isEqualTo(task).isNotSameAs(task);
+        assertThat(duplicate.hashCode()).isEqualTo(task.hashCode());
+        assertThat(task.toString()).contains("topicGroupId=" + group, "partition=" + partition);
+    }
+
+    private static void assertTaskOffsetContract(TaskOffsetSum task) {
+        TaskOffsetSum duplicate = task.duplicate();
+        assertThat(task.lowestSupportedVersion()).isEqualTo((short) 7);
+        assertThat(task.highestSupportedVersion()).isEqualTo(Short.MAX_VALUE);
+        assertThat(task.topicGroupId()).isEqualTo(8);
+        assertThat(task.partition()).isEqualTo(9);
+        assertThat(task.offsetSum()).isEqualTo(5678L);
+        assertThat(task.namedTopology()).isEqualTo("payments");
+        assertThat(task.unknownTaggedFields()).isEmpty();
+        assertThat(duplicate).isEqualTo(task).isNotSameAs(task);
+        assertThat(duplicate.hashCode()).isEqualTo(task.hashCode());
+        assertThat(task.partitionToOffsetSum()).isEmpty();
+        assertThat(task.toString()).contains("namedTopology='payments'");
+    }
+
+    private static void assertClientTagContract(ClientTag tag) {
+        ClientTag duplicate = tag.duplicate();
+        assertThat(tag.lowestSupportedVersion()).isEqualTo((short) 11);
+        assertThat(tag.highestSupportedVersion()).isEqualTo(Short.MAX_VALUE);
+        assertThat(tag.key()).asString(StandardCharsets.UTF_8).isEqualTo("zone");
+        assertThat(tag.value()).asString(StandardCharsets.UTF_8).isEqualTo("west");
+        assertThat(tag.unknownTaggedFields()).isEmpty();
+        assertThat(duplicate).isEqualTo(tag).isNotSameAs(tag);
+        assertThat(duplicate.hashCode()).isEqualTo(tag.hashCode());
+        assertThat(tag.toString()).contains("key=", "value=");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TopologyDslCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TopologyDslCoverageTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TopologyDslCoverageTest {
+
+    private static final Serde<String> STRINGS = Serdes.String();
+
+    @Test
+    void streamTransformationsProduceTheExpectedProcessorGraph() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> source = builder.stream("events", Consumed.with(STRINGS, STRINGS));
+        KStream<String, String> transformed = source
+                .filterNot((key, value) -> value.isBlank(), Named.as("non-blank"))
+                .selectKey((key, value) -> value, Named.as("select-value-key"))
+                .map((key, value) -> KeyValue.pair(key.toUpperCase(), value), Named.as("uppercase-key"))
+                .mapValues(value -> value.trim(), Named.as("trim-value"))
+                .mapValues((key, value) -> key + ":" + value, Named.as("prefix-value"))
+                .flatMap((key, value) -> List.of(KeyValue.pair(key, value)), Named.as("flat-map"))
+                .flatMapValues(value -> List.of(value, value.toUpperCase()), Named.as("duplicate-value"))
+                .flatMapValues((key, value) -> List.of(key + value), Named.as("combine-value"))
+                .peek((key, value) -> { }, Named.as("audit"));
+
+        transformed.split(Named.as("route-"))
+                .branch((key, value) -> value.length() > 5, Branched.as("long"))
+                .defaultBranch(Branched.as("short"));
+        transformed.foreach((key, value) -> { }, Named.as("consume"));
+        transformed.merge(source, Named.as("merge-original"))
+                .repartition(Repartitioned.<String, String>as("normalized").withNumberOfPartitions(2))
+                .to("normalized-output", Produced.with(STRINGS, STRINGS));
+        transformed.through("intermediate", Produced.with(STRINGS, STRINGS))
+                .toTable(Named.as("latest"), Materialized.as("latest-store"));
+        transformed.groupBy((key, value) -> value, Grouped.with(STRINGS, STRINGS))
+                .count(Named.as("value-counts"), Materialized.as("count-store"));
+
+        String description = builder.build().describe().toString();
+        assertThat(description).contains(
+                "non-blank", "select-value-key", "uppercase-key", "trim-value", "prefix-value",
+                "flat-map", "duplicate-value", "combine-value", "audit", "route-long",
+                "route-short", "consume", "merge-original", "normalized-repartition",
+                "normalized-output", "intermediate", "latest", "value-counts");
+    }
+
+    @Test
+    void streamAndTableJoinsProduceNamedJoinGraphs() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> orders = builder.stream("orders", Consumed.with(STRINGS, STRINGS));
+        KStream<String, String> payments = builder.stream("payments", Consumed.with(STRINGS, STRINGS));
+        KTable<String, String> customers = builder.table(
+                "customers", Consumed.with(STRINGS, STRINGS), Materialized.as("customers-store"));
+        KTable<String, String> regions = builder.table(
+                "regions", Consumed.with(STRINGS, STRINGS), Materialized.as("regions-store"));
+        GlobalKTable<String, String> countries = builder.globalTable(
+                "countries", Consumed.with(STRINGS, STRINGS), Materialized.as("countries-store"));
+        JoinWindows windows = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(1));
+        StreamJoined<String, String, String> streamJoined = StreamJoined
+                .with(STRINGS, STRINGS, STRINGS)
+                .withName("order-payment");
+
+        orders.join(payments, (left, right) -> left + right, windows, streamJoined)
+                .to("paid-orders");
+        orders.leftJoin(payments, (key, left, right) -> left + right, windows,
+                        streamJoined.withName("optional-payment"))
+                .to("possibly-paid-orders");
+        orders.outerJoin(payments, (left, right) -> left + right, windows,
+                        streamJoined.withName("all-orders-payments"))
+                .to("all-orders-payments-output");
+        orders.join(customers, (order, customer) -> order + customer,
+                        Joined.with(STRINGS, STRINGS, STRINGS).withName("customer-join"))
+                .to("customer-orders");
+        orders.leftJoin(customers, (key, order, customer) -> order + customer,
+                        Joined.with(STRINGS, STRINGS, STRINGS).withName("optional-customer"))
+                .to("optional-customer-orders");
+        orders.join(countries, (key, order) -> key, (order, country) -> order + country,
+                        Named.as("country-join"))
+                .to("country-orders");
+        orders.leftJoin(countries, (key, order) -> key, (key, order, country) -> order + country,
+                        Named.as("optional-country"))
+                .to("optional-country-orders");
+
+        customers.filter((key, value) -> !value.isBlank(), Named.as("valid-customer"),
+                        Materialized.as("valid-customer-store"))
+                .mapValues((key, value) -> value.toUpperCase(), Named.as("uppercase-customer"),
+                        Materialized.as("uppercase-customer-store"));
+        customers.join(regions, (customer, region) -> customer + region,
+                        Named.as("customer-region"), Materialized.as("customer-region-store"));
+        customers.leftJoin(regions, (customer, region) -> customer + region,
+                        Named.as("optional-region"), Materialized.as("optional-region-store"));
+        customers.outerJoin(regions, (customer, region) -> customer + region,
+                        Named.as("all-customer-regions"), Materialized.as("all-customer-regions-store"));
+        customers.join(regions, value -> value, (customer, region) -> customer + region,
+                        TableJoined.as("foreign-region"), Materialized.as("foreign-region-store"));
+
+        String description = builder.build().describe().toString();
+        assertThat(description).contains(
+                "order-payment", "optional-payment", "all-orders-payments", "customer-join",
+                "optional-customer", "country-join", "optional-country", "valid-customer",
+                "uppercase-customer", "customer-region", "optional-region", "all-customer-regions",
+                "foreign-region");
+    }
+
+    @Test
+    void storeFactoriesRetainTheirStorageAndRetentionContracts() {
+        KeyValueBytesStoreSupplier persistent = Stores.persistentKeyValueStore("persistent-kv");
+        KeyValueBytesStoreSupplier memory = Stores.inMemoryKeyValueStore("memory-kv");
+        KeyValueBytesStoreSupplier lru = Stores.lruMap("bounded-kv", 20);
+        VersionedBytesStoreSupplier versioned = Stores.persistentVersionedKeyValueStore(
+                "versioned-kv", Duration.ofHours(1), Duration.ofMinutes(5));
+        WindowBytesStoreSupplier window = Stores.persistentWindowStore(
+                "window", Duration.ofHours(1), Duration.ofMinutes(5), true);
+        WindowBytesStoreSupplier timestampedWindow = Stores.persistentTimestampedWindowStore(
+                "timestamped-window", Duration.ofHours(1), Duration.ofMinutes(5), false);
+        SessionBytesStoreSupplier session = Stores.inMemorySessionStore("session", Duration.ofMinutes(30));
+
+        StoreBuilder<?> persistentBuilder = Stores.keyValueStoreBuilder(persistent, STRINGS, STRINGS)
+                .withCachingEnabled().withLoggingEnabled(Map.of("cleanup.policy", "compact"));
+        StoreBuilder<?> memoryBuilder = Stores.keyValueStoreBuilder(memory, STRINGS, STRINGS);
+        StoreBuilder<?> lruBuilder = Stores.keyValueStoreBuilder(lru, STRINGS, STRINGS);
+        StoreBuilder<?> versionedBuilder = Stores.versionedKeyValueStoreBuilder(versioned, STRINGS, STRINGS);
+        StoreBuilder<?> windowBuilder = Stores.windowStoreBuilder(window, STRINGS, STRINGS);
+        StoreBuilder<?> timestampedBuilder = Stores.timestampedWindowStoreBuilder(
+                timestampedWindow, STRINGS, STRINGS);
+        StoreBuilder<?> sessionBuilder = Stores.sessionStoreBuilder(session, STRINGS, STRINGS);
+
+        assertThat(persistentBuilder.name()).isEqualTo("persistent-kv");
+        assertThat(persistentBuilder.loggingEnabled()).isTrue();
+        assertThat(persistentBuilder.logConfig()).containsEntry("cleanup.policy", "compact");
+        assertThat(memoryBuilder.name()).isEqualTo("memory-kv");
+        assertThat(lruBuilder.name()).isEqualTo("bounded-kv");
+        assertThat(versionedBuilder.name()).isEqualTo("versioned-kv");
+        assertThat(windowBuilder.name()).isEqualTo("window");
+        assertThat(timestampedBuilder.name()).isEqualTo("timestamped-window");
+        assertThat(sessionBuilder.name()).isEqualTo("session");
+        assertThat(persistent.get().persistent()).isTrue();
+        assertThat(memory.get().persistent()).isFalse();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/WindowingAndJoinConfigurationCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/WindowingAndJoinConfigurationCoverageTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class WindowingAndJoinConfigurationCoverageTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void timeWindowsAssignRecordsToTumblingAndHoppingWindows() {
+        TimeWindows tumbling = TimeWindows.ofSizeAndGrace(Duration.ofSeconds(10), Duration.ofSeconds(2));
+        TimeWindows hopping = tumbling.advanceBy(Duration.ofSeconds(4));
+        TimeWindows equivalent = TimeWindows.ofSizeAndGrace(Duration.ofSeconds(10), Duration.ofSeconds(2))
+                .advanceBy(Duration.ofSeconds(4));
+
+        assertThat(tumbling.windowsFor(12_000L)).containsOnlyKeys(10_000L);
+        assertThat(hopping.windowsFor(12_000L)).containsOnlyKeys(4_000L, 8_000L, 12_000L);
+        assertThat(hopping.windowsFor(-1L)).isEmpty();
+        assertThat(hopping.size()).isEqualTo(10_000L);
+        assertThat(hopping.gracePeriodMs()).isEqualTo(2_000L);
+        assertThat(hopping).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(hopping).isNotEqualTo(tumbling).isNotEqualTo(null).isNotEqualTo("window");
+        assertThat(hopping.toString()).contains("sizeMs=10000", "advanceMs=4000", "graceMs=2000");
+
+        TimeWindows noGrace = TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(1));
+        assertThat(noGrace.gracePeriodMs()).isZero();
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> noGrace.grace(Duration.ofMillis(1)));
+        assertThatIllegalArgumentException().isThrownBy(() -> hopping.advanceBy(Duration.ZERO));
+        assertThatIllegalArgumentException().isThrownBy(() -> hopping.advanceBy(Duration.ofSeconds(11)));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> TimeWindows.ofSizeAndGrace(Duration.ZERO, Duration.ZERO));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> TimeWindows.ofSizeAndGrace(Duration.ofSeconds(1), Duration.ofMillis(-1)));
+
+        TimeWindows legacy = TimeWindows.of(Duration.ofSeconds(10)).grace(Duration.ofSeconds(3));
+        assertThat(legacy.gracePeriodMs()).isEqualTo(3_000L);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void joinWindowsRetainAsymmetricBoundsAndGrace() {
+        JoinWindows symmetric = JoinWindows.ofTimeDifferenceAndGrace(
+                Duration.ofSeconds(5), Duration.ofSeconds(2));
+        JoinWindows asymmetric = symmetric.before(Duration.ofSeconds(3)).after(Duration.ofSeconds(7));
+        JoinWindows equivalent = JoinWindows.ofTimeDifferenceAndGrace(
+                Duration.ofSeconds(5), Duration.ofSeconds(2))
+                .before(Duration.ofSeconds(3)).after(Duration.ofSeconds(7));
+
+        assertThat(asymmetric.beforeMs).isEqualTo(3_000L);
+        assertThat(asymmetric.afterMs).isEqualTo(7_000L);
+        assertThat(asymmetric.size()).isEqualTo(10_000L);
+        assertThat(asymmetric.gracePeriodMs()).isEqualTo(2_000L);
+        assertThat(asymmetric).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(asymmetric).isNotEqualTo(symmetric).isNotEqualTo(null).isNotEqualTo("window");
+        assertThat(asymmetric.toString()).contains("beforeMs=3000", "afterMs=7000", "graceMs=2000");
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> asymmetric.windowsFor(1L));
+
+        JoinWindows noGrace = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(1));
+        assertThat(noGrace.gracePeriodMs()).isZero();
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> noGrace.grace(Duration.ofMillis(1)));
+        assertThatIllegalArgumentException().isThrownBy(() -> noGrace.before(Duration.ofSeconds(-2)));
+
+        JoinWindows legacy = JoinWindows.of(Duration.ofSeconds(1)).grace(Duration.ofSeconds(3));
+        assertThat(legacy.gracePeriodMs()).isEqualTo(3_000L);
+        InspectableJoinWindows copy = new InspectableJoinWindows(legacy);
+        assertThat(copy.beforeMs).isEqualTo(legacy.beforeMs);
+        assertThat(copy.afterMs).isEqualTo(legacy.afterMs);
+        assertThat(copy.gracePeriodMs()).isEqualTo(legacy.gracePeriodMs());
+    }
+
+    @Test
+    void timeWindowsAndWindowedKeysUseHalfOpenIntervalSemantics() {
+        TimeWindow first = new TimeWindow(10L, 20L);
+        TimeWindow overlapping = new TimeWindow(19L, 30L);
+        TimeWindow adjacent = new TimeWindow(20L, 30L);
+        Windowed<String> windowed = new Windowed<>("order-7", first);
+        Windowed<String> equivalent = new Windowed<>("order-7", new TimeWindow(10L, 20L));
+
+        assertThat(first.overlap(overlapping)).isTrue();
+        assertThat(first.overlap(adjacent)).isFalse();
+        assertThat(first.startTime()).isEqualTo(Instant.ofEpochMilli(10L));
+        assertThat(first.endTime()).isEqualTo(Instant.ofEpochMilli(20L));
+        assertThat(windowed.key()).isEqualTo("order-7");
+        assertThat(windowed.window()).isEqualTo(first);
+        assertThat(windowed).isEqualTo(equivalent).hasSameHashCodeAs(equivalent);
+        assertThat(windowed).isNotEqualTo(new Windowed<>("order-8", first)).isNotEqualTo("order-7");
+        assertThat(windowed.toString()).isEqualTo("[order-7@10/20]");
+        assertThatIllegalArgumentException().isThrownBy(() -> new TimeWindow(10L, 10L));
+    }
+
+    @Test
+    void joinedConfigurationUpdatesAreImmutableAndComposable() {
+        Serde<String> keySerde = Serdes.String();
+        Serde<Long> valueSerde = Serdes.Long();
+        Serde<Double> otherSerde = Serdes.Double();
+        Joined<String, Long, Double> initial = Joined.with(keySerde, valueSerde, otherSerde);
+        Joined<String, Long, Double> configured = initial
+                .withName("lookup")
+                .withGracePeriod(Duration.ofSeconds(2));
+        InspectableJoined<String, Long, Double> inspected = new InspectableJoined<>(configured);
+
+        assertThat(initial.gracePeriod()).isNull();
+        assertThat(configured.keySerde()).isSameAs(keySerde);
+        assertThat(configured.valueSerde()).isSameAs(valueSerde);
+        assertThat(configured.otherValueSerde()).isSameAs(otherSerde);
+        assertThat(configured.gracePeriod()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(inspected.name()).isEqualTo("lookup");
+
+        assertThat(new InspectableJoined<>(Joined.with(keySerde, valueSerde, otherSerde, "four")).name())
+                .isEqualTo("four");
+        assertThat(new InspectableJoined<>(Joined.with(
+                keySerde, valueSerde, otherSerde, "five", Duration.ofSeconds(5))).name())
+                .isEqualTo("five");
+        assertThat(Joined.<String, Long, Double>keySerde(keySerde).keySerde()).isSameAs(keySerde);
+        assertThat(Joined.<String, Long, Double>valueSerde(valueSerde).valueSerde()).isSameAs(valueSerde);
+        assertThat(Joined.<String, Long, Double>otherValueSerde(otherSerde).otherValueSerde()).isSameAs(otherSerde);
+        assertThat(new InspectableJoined<>(Joined.<String, Long, Double>as("named")).name()).isEqualTo("named");
+        assertThat(initial.withKeySerde(Serdes.String()).keySerde()).isNotNull();
+        assertThat(initial.withValueSerde(Serdes.Long()).valueSerde()).isNotNull();
+        assertThat(initial.withOtherValueSerde(Serdes.Double()).otherValueSerde()).isNotNull();
+    }
+
+    @Test
+    void streamJoinedConfigurationCarriesStoresSerdesAndLoggingPolicy() {
+        Serde<String> keySerde = Serdes.String();
+        Serde<Long> valueSerde = Serdes.Long();
+        Serde<Double> otherSerde = Serdes.Double();
+        WindowBytesStoreSupplier leftStore = Stores.inMemoryWindowStore(
+                "left", Duration.ofMinutes(2), Duration.ofSeconds(10), false);
+        WindowBytesStoreSupplier rightStore = Stores.inMemoryWindowStore(
+                "right", Duration.ofMinutes(2), Duration.ofSeconds(10), false);
+
+        StreamJoined<String, Long, Double> configured = StreamJoined
+                .with(keySerde, valueSerde, otherSerde)
+                .withName("processor")
+                .withStoreName("joined")
+                .withThisStoreSupplier(leftStore)
+                .withOtherStoreSupplier(rightStore)
+                .withLoggingEnabled(Map.of("cleanup.policy", "compact"));
+        InspectableStreamJoined<String, Long, Double> inspected = new InspectableStreamJoined<>(configured);
+
+        assertThat(inspected.keySerde()).isSameAs(keySerde);
+        assertThat(inspected.valueSerde()).isSameAs(valueSerde);
+        assertThat(inspected.otherValueSerde()).isSameAs(otherSerde);
+        assertThat(inspected.leftStore()).isSameAs(leftStore);
+        assertThat(inspected.rightStore()).isSameAs(rightStore);
+        assertThat(inspected.name()).isEqualTo("processor");
+        assertThat(inspected.storeName()).isEqualTo("joined");
+        assertThat(inspected.loggingEnabled()).isTrue();
+        assertThat(inspected.topicConfig()).containsEntry("cleanup.policy", "compact");
+        assertThat(configured.toString()).contains("processor", "joined", "cleanup.policy", "loggingEnabled=true");
+
+        assertThat(new InspectableStreamJoined<>(StreamJoined.<String, Long, Double>with(leftStore, rightStore))
+                .leftStore()).isSameAs(leftStore);
+        assertThat(new InspectableStreamJoined<>(StreamJoined.<String, Long, Double>as("store")).storeName())
+                .isEqualTo("store");
+        assertThat(new InspectableStreamJoined<>(configured.withLoggingDisabled()).loggingEnabled()).isFalse();
+        assertThat(new InspectableStreamJoined<>(configured.withKeySerde(Serdes.String())).keySerde()).isNotNull();
+        assertThat(new InspectableStreamJoined<>(configured.withValueSerde(Serdes.Long())).valueSerde()).isNotNull();
+        assertThat(new InspectableStreamJoined<>(configured.withOtherValueSerde(Serdes.Double())).otherValueSerde())
+                .isNotNull();
+    }
+
+    private static final class InspectableJoinWindows extends JoinWindows {
+        private InspectableJoinWindows(final JoinWindows windows) {
+            super(windows);
+        }
+    }
+
+    private static final class InspectableJoined<K, V, VO> extends Joined<K, V, VO> {
+        private InspectableJoined(final Joined<K, V, VO> joined) {
+            super(joined);
+        }
+
+        private String name() {
+            return name;
+        }
+    }
+
+    private static final class InspectableStreamJoined<K, V, VO> extends StreamJoined<K, V, VO> {
+        private InspectableStreamJoined(final StreamJoined<K, V, VO> joined) {
+            super(joined);
+        }
+
+        private Serde<K> keySerde() {
+            return keySerde;
+        }
+
+        private Serde<V> valueSerde() {
+            return valueSerde;
+        }
+
+        private Serde<VO> otherValueSerde() {
+            return otherValueSerde;
+        }
+
+        private WindowBytesStoreSupplier leftStore() {
+            return thisStoreSupplier;
+        }
+
+        private WindowBytesStoreSupplier rightStore() {
+            return otherStoreSupplier;
+        }
+
+        private String name() {
+            return name;
+        }
+
+        private String storeName() {
+            return storeName;
+        }
+
+        private boolean loggingEnabled() {
+            return loggingEnabled;
+        }
+
+        private Map<String, String> topicConfig() {
+            return topicConfig;
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+  "coordinates": "org.apache.kafka:kafka-streams:3.6.2"
+}


### PR DESCRIPTION
## Unguided code coverage baseline

- Source issue: #9055 (not resolved by this PR)
- Coordinate: `org.apache.kafka:kafka-streams:3.6.2`
- Coverage suite path: `tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement`

This is the unguided control arm of §WF-code-coverage-baseline: the agent was given only the library's main jar and the JaCoCo report, with no inventory, ranking, eligibility filter, or phase split.

## Coverage

- Baseline: 1789/7065 (25.32%)
- Final: 2709/7065 (38.34%)
- Delta: +13.02pp (+920 methods)
- Remaining uncovered: 4356

### Denominator

The percentage above counts **library-declared methods only**: the JaCoCo method records whose declaring class is declared by the resolved main jar (§WF-code-coverage-baseline.3.2). It is not the raw JaCoCo percentage, which also counts every other instrumented class on the test runtime classpath.

- JaCoCo methods in report: 19336
- Excluded as non-library: 12271
- Library methods (denominator): 7065
- Main jars (exact-name): `kafka-streams-3.6.2.jar`

### Top 15 packages by remaining uncovered methods

| Package | Methods | Covered | Uncovered | % |
|---|--:|--:|--:|--:|
| `org.apache.kafka.streams.state.internals` | 2246 | 280 | 1966 | 12.47 |
| `org.apache.kafka.streams.processor.internals` | 1728 | 808 | 920 | 46.76 |
| `org.apache.kafka.streams.kstream.internals` | 980 | 321 | 659 | 32.76 |
| `org.apache.kafka.streams.processor.internals.assignment` | 363 | 143 | 220 | 39.39 |
| `org.apache.kafka.streams` | 268 | 112 | 156 | 41.79 |
| `org.apache.kafka.streams.kstream.internals.foreignkeyjoin` | 91 | 28 | 63 | 30.77 |
| `org.apache.kafka.streams.kstream` | 255 | 193 | 62 | 75.69 |
| `org.apache.kafka.streams.processor.internals.namedtopology` | 56 | 2 | 54 | 3.57 |
| `org.apache.kafka.streams.state` | 126 | 72 | 54 | 57.14 |
| `org.apache.kafka.streams.processor.internals.tasks` | 40 | 0 | 40 | 0.0 |
| `org.apache.kafka.streams.kstream.internals.graph` | 200 | 164 | 36 | 82.0 |
| `org.apache.kafka.streams.kstream.internals.suppress` | 80 | 47 | 33 | 58.75 |
| `org.apache.kafka.streams.processor.internals.metrics` | 125 | 95 | 30 | 76.0 |
| `org.apache.kafka.streams.errors` | 69 | 48 | 21 | 69.57 |
| `org.apache.kafka.streams.state.internals.metrics` | 90 | 75 | 15 | 83.33 |

8 further packages omitted.

## Token usage

| Phase | Input | Input (cached) | Output |
|---|--:|--:|--:|
| coverage | 860,704 | 11,876,352 | 75,620 |
| convert | 72,300 | 436,224 | 5,383 |
| prepare | 43,622 | 385,536 | 5,012 |
| **Total** | **976,626** | **12,698,112** | **86,015** |

Input is uncached input tokens; Input (cached) is cache reads.
