### PR TITLE
Count coverage on one frozen method universe

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -661,9 +661,9 @@ states:
 
       # Step 5: finalize separate API/deep JaCoCo metrics and guidance-only PGO
       # evidence from the recorded reports and target state.
-      def report_bounds(directory: str, stem: str) -> tuple:
+      def report_bounds(directory: str, stem: str, suffix: str = ".json") -> tuple:
           reports = sorted(
-              Path(directory).glob(f"{stem}-[0-9]*.json"),
+              Path(directory).glob(f"{stem}-[0-9]*{suffix}"),
               key=lambda p: int(p.stem.rsplit("-", 1)[1]),
           )
           if not reports:
@@ -672,6 +672,14 @@ states:
 
       api_baseline, api_final = report_bounds("runtime/code-coverage/validation", "api-cover-report")
       deep_baseline, deep_final = report_bounds("runtime/code-coverage/discovery", "discovery-report")
+      # Whole-run checkpoints. The API/deep boundary is read from the deep
+      # phase's own first report so both universes are counted from one instant:
+      # pairing it with the API phase's last report would put two different
+      # instants of the run on one scale.
+      jacoco_run_start, _ = report_bounds("runtime/code-coverage/validation", "jacoco", ".xml")
+      jacoco_after_api, jacoco_final = report_bounds(
+          "runtime/code-coverage/discovery", "jacoco-deep", ".xml"
+      )
       finalize_command = [
           sys.executable,
           f"{work_path}/utility_scripts/code_coverage_finalize.py",
@@ -681,6 +689,9 @@ states:
           "--api-final", str(api_final),
           "--deep-baseline", str(deep_baseline),
           "--deep-final", str(deep_final),
+          "--jacoco-run-start", str(jacoco_run_start),
+          "--jacoco-after-api", str(jacoco_after_api),
+          "--jacoco-final", str(jacoco_final),
           "--output-dir", "runtime/code-coverage/finalization",
       ]
       for validation_command in [checkstyle_command] + jvm_commands:

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -255,8 +255,8 @@
     suffix deletes the head branch of an earlier run's pull request for this
     same coordinate and takes its place.
   - Open a pull request against `{{repo}}` base `{{pr_base_branch}}`.
-  - Include source issue, coordinate, coverage suite path, separate baseline and
-    final API/deep JaCoCo coverage, the two phases combined, coverage deltas,
+  - Include source issue, coordinate, coverage suite path, baseline and final
+    API/deep JaCoCo coverage against one shared denominator, coverage deltas,
     sampled guidance evidence, completed, skipped, exhausted, or failed targets,
     validation commands, and per-phase token usage in the PR body.
   - The helper writes all of that from `final-metrics.json` and the Rhei

--- a/forge/docs/workflows/code-coverage-improvement.md
+++ b/forge/docs/workflows/code-coverage-improvement.md
@@ -439,19 +439,16 @@ The Rhei template should decompose the workflow into these phases:
    caught before publication rather than in review (§2). No Native Image
    validation runs at this stage; a nonzero exit code names the failed step.
 8. **Publication** — open a PR with source issue, coordinate, coverage suite,
-   baseline/final JaCoCo coverage reported against the JaCoCo-reportable method
-   count of each guidance phase, both phases combined into one figure, and
-   per-phase token usage read from the Rhei accounting directory. The body
+   baseline/final JaCoCo coverage for both guidance phases reported against one
+   shared denominator, and per-phase token usage read from the Rhei accounting
+   directory. The body
    carries no per-target roster and no validation commands: the target counts
    restate what the coverage figures already say, and the commands embed the
    run's own absolute worktree paths, which no reader of the PR can execute.
    Both stay in the finalization artifacts, which is where a reviewer who wants
-   per-target detail reads it. Coverage percentages divide by the
-   methods JaCoCo reports, not by every inventory entry: entries JaCoCo never
-   reports are ones no run can cover, and charging them to the run understates
-   it. The combined figure adds the two phases directly, which is sound because
-   the deep universe holds exactly the library methods the API inventory does
-   not. A phase whose accounting is not yet written is omitted from the token
+   per-target detail reads it. Coverage is reported as sequential run
+   checkpoints under the coverage accounting rule below (§4.1), never as two
+   phases on their own scales. A phase whose accounting is not yet written is omitted from the token
    table rather than reported as zero; publication itself is normally omitted,
    since its own invocations are still running when the body is built. Sampled
    PGO evidence stays in the local finalization summary and is not published in
@@ -463,6 +460,38 @@ The Rhei template should decompose the workflow into these phases:
    earlier one — a different model, agent, or pass budget measured against the
    same library — sets the suffix so each run owns its own branch and each pull
    request survives the next run.
+
+
+### 4.1 Coverage accounting
+
+Every count and every ratio the workflow publishes obeys three rules. They exist
+because violating them silently understates a run: an earlier revision reported
+each phase against its own roster and took the two phases' snapshots at
+different points in the run, which both inflated the baseline and discarded the
+public API methods the deep phase covered after the API phase's last report.
+
+1. **One universe, frozen once.** The denominator is the complete set of library
+   method **ids** JaCoCo can rule on: the API inventory's reportable entries plus
+   the deep roster, which are disjoint by construction because the deep roster is
+   exactly the library methods the inventory does not hold. It is resolved once,
+   from the run's own rosters, and never recomputed per phase. Inventory entries
+   JaCoCo does not report are excluded — no run can cover them, so charging them
+   to a denominator understates every figure that divides by it.
+2. **One report per checkpoint, one routine.** A checkpoint counts both universes
+   from a single JaCoCo report by looking up the frozen ids. Summary fields that
+   separate phases computed for themselves are never added together: they belong
+   to different instants of the run, and combining them presents two different
+   instants as one figure. The API/deep boundary is therefore read from the deep
+   phase's own first report, not from the API phase's last one.
+3. **A missing id is an error, not a zero.** If a frozen id is absent from a later
+   report the universe moved, and finalization fails rather than quietly
+   reporting against a smaller denominator.
+
+Each phase's gain is then the distance between consecutive checkpoints, the
+phase gains sum to the run's gain, and no separate combined figure is needed.
+The per-phase `apiJacoco` and `deepJacoco` blocks remain in the finalization
+artifacts, since each phase's own guidance is ranked against its own roster;
+they are phase records, not run figures.
 
 The pipeline tasks run unreviewed: deterministic helpers, schema-validated
 artifacts, and zero-exit validation gates decide their completion. The

--- a/forge/git_scripts/make_pr_code_coverage_improvement.py
+++ b/forge/git_scripts/make_pr_code_coverage_improvement.py
@@ -5,8 +5,8 @@
 
 """Publish schema-validated code coverage improvement evidence.
 
-The PR body reports each guidance phase against its JaCoCo-reportable method
-count, the two phases combined, and per-phase token usage. Per-target rosters
+The PR body reports the run as sequential checkpoints against one shared
+denominator, every library method JaCoCo reports, plus per-phase token usage. Per-target rosters
 and validation commands stay in the finalization artifacts, which is where a
 reviewer reads them from
 (§WF-code-coverage-improvement, §AR-forge-verification-publication-boundary).
@@ -65,54 +65,73 @@ def _total_percent(covered: int, total: int) -> float:
     return round(100 * covered / total, 2) if total else 0.0
 
 
-def _reportable_total(snapshot: dict[str, Any]) -> int:
-    """The denominator JaCoCo can actually rule on.
+#: Checkpoint name -> the row label a reader sees.
+CHECKPOINT_LABELS: dict[str, str] = {
+    "runStart": "Run start",
+    "afterApiPhase": "After Simple Jacoco guidance phase",
+    "final": "After PGO guidance phase (final)",
+}
 
-    The API inventory carries both `total`, every inventory entry, and
-    `measured`, the entries JaCoCo reports at all. The difference is methods no
-    run can ever cover, so dividing by `total` understates the phase and
-    contradicts the `coveragePercent` the same document records. The deep
-    snapshot has no such split and falls back to `total`.
+#: Phase name -> the row label a reader sees.
+PHASE_LABELS: dict[str, str] = {
+    "api": "Simple Jacoco guidance phase",
+    "deep": "PGO guidance phase",
+}
+
+
+def _universe_lines(run: dict[str, Any]) -> list[str]:
+    """The run as one timeline on one denominator.
+
+    Every figure divides by the complete count of library methods JaCoCo can
+    rule on, so each phase's gain is the distance from the checkpoint the
+    previous phase ended on and the phase gains sum to the run's gain. Reporting
+    a phase against its own roster instead put two different instants of the run
+    on two different scales, which is what made the figures read as inconsistent
+    (§WF-code-coverage-improvement.4.1).
     """
-    return snapshot.get("measured", snapshot["total"])
-
-
-def _jacoco_lines(label: str, evidence: dict[str, Any]) -> list[str]:
-    baseline: dict[str, Any] = evidence["baseline"]
-    final: dict[str, Any] = evidence["final"]
-    total: int = _reportable_total(final)
-    baseline_percent: float = _total_percent(baseline["covered"], total)
-    final_percent: float = _total_percent(final["covered"], total)
-    return [
-        f"### {label}",
+    universe: int = run["universe"]
+    checkpoints: list[dict[str, Any]] = run["checkpoints"]
+    lines: list[str] = [
+        f"Every figure divides by the same denominator: the {universe} library "
+        f"methods JaCoCo can rule on, made up of {run['apiUniverse']} public API "
+        f"methods and {run['deepUniverse']} internal methods, which are disjoint "
+        "by construction. Each checkpoint is counted over that one frozen set of "
+        "method ids from a single JaCoCo report, so every phase starts where the "
+        "previous phase ended.",
         "",
-        f"- Baseline: {baseline['covered']}/{total} ({baseline_percent}%)",
-        f"- Final: {final['covered']}/{total} ({final_percent}%)",
-        f"- Delta: {_signed(round(final_percent - baseline_percent, 2))}pp",
-        f"- Remaining uncovered: {total - final['covered']}",
+        "| Checkpoint | Covered | Share |",
+        "|---|--:|--:|",
     ]
-
-
-def _combined_lines(api: dict[str, Any], deep: dict[str, Any]) -> list[str]:
-    """API and deep coverage as one number.
-
-    The two universes are disjoint by construction: the deep universe holds
-    exactly the library methods the API inventory does not, so their measured
-    counts and covered counts add without double counting.
-    """
-    total: int = _reportable_total(api["final"]) + _reportable_total(deep["final"])
-    baseline: int = api["baseline"]["covered"] + deep["baseline"]["covered"]
-    final: int = api["final"]["covered"] + deep["final"]["covered"]
-    baseline_percent: float = _total_percent(baseline, total)
-    final_percent: float = _total_percent(final, total)
-    return [
-        "### Both phases combined",
+    lines += [
+        f"| {CHECKPOINT_LABELS[point['name']]} | {point['covered']}/{universe} "
+        f"| {point['coveragePercent']}% |"
+        for point in checkpoints
+    ]
+    lines.append("")
+    lines += [
+        f"- {PHASE_LABELS[phase['name']]}: {_signed(phase['covered'])} methods, "
+        f"{_signed(phase['coveragePercentagePoints'])}pp"
+        for phase in run["phases"]
+    ]
+    first: dict[str, Any] = checkpoints[0]
+    last: dict[str, Any] = checkpoints[-1]
+    lines += [
+        f"- Run total: {_signed(last['covered'] - first['covered'])} methods, "
+        f"{_signed(round(last['coveragePercent'] - first['coveragePercent'], 2))}pp",
+        f"- Remaining uncovered: {last['uncovered']} of {universe}",
         "",
-        f"- Baseline: {baseline}/{total} ({baseline_percent}%)",
-        f"- Final: {final}/{total} ({final_percent}%)",
-        f"- Delta: {_signed(round(final_percent - baseline_percent, 2))}pp",
-        f"- Remaining uncovered: {total - final}",
+        "Where the coverage and the remaining headroom sit:",
+        "",
+        "| Method universe | Run start | Final | Still uncovered |",
+        "|---|--:|--:|--:|",
+        f"| Public API | {first['apiCovered']}/{run['apiUniverse']} | "
+        f"{last['apiCovered']}/{run['apiUniverse']} | "
+        f"{run['apiUniverse'] - last['apiCovered']} |",
+        f"| Internal | {first['deepCovered']}/{run['deepUniverse']} | "
+        f"{last['deepCovered']}/{run['deepUniverse']} | "
+        f"{run['deepUniverse'] - last['deepCovered']} |",
     ]
+    return lines
 
 
 def _phase_name(file_name: str) -> str:
@@ -203,11 +222,7 @@ def build_pull_request_body(
         "## JaCoCo coverage",
         "",
     ]
-    lines += _jacoco_lines("Simple Jacoco guidance phase", metrics["apiJacoco"])
-    lines += [""] + _jacoco_lines(
-        "PGO guidance phase", metrics["deepJacoco"]
-    )
-    lines += [""] + _combined_lines(metrics["apiJacoco"], metrics["deepJacoco"])
+    lines += _universe_lines(metrics["runCoverage"])
     lines += [""]
     token_lines: list[str] = _token_lines(token_usage or [])
     if token_lines:

--- a/forge/schemas/code_coverage_final_metrics_schema.json
+++ b/forge/schemas/code_coverage_final_metrics_schema.json
@@ -7,6 +7,7 @@
     "schemaVersion",
     "coordinate",
     "coverageSuitePath",
+    "runCoverage",
     "apiJacoco",
     "deepJacoco",
     "pgoGuidance",
@@ -15,12 +16,13 @@
     "needsHumanIntervention"
   ],
   "properties": {
-    "schemaVersion": {"const": "1.0.0"},
+    "schemaVersion": {"const": "1.1.0"},
     "coordinate": {
       "type": "string",
       "pattern": "^[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+:[A-Za-z0-9_.+-]+$"
     },
     "coverageSuitePath": {"type": "string", "minLength": 1},
+    "runCoverage": {"$ref": "#/$defs/runCoverage"},
     "apiJacoco": {"$ref": "#/$defs/apiEvidence"},
     "deepJacoco": {"$ref": "#/$defs/deepEvidence"},
     "pgoGuidance": {"$ref": "#/$defs/pgoGuidance"},
@@ -53,6 +55,65 @@
     }
   ],
   "$defs": {
+    "runCoverage": {
+      "description": "Whole-run coverage on one denominator: the complete count of library methods JaCoCo can rule on. Every checkpoint is counted over that one frozen method-id set from a single JaCoCo report, so each phase begins where the previous phase ended.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "universe",
+        "apiUniverse",
+        "deepUniverse",
+        "checkpoints",
+        "phases"
+      ],
+      "properties": {
+        "universe": {"type": "integer", "minimum": 0},
+        "apiUniverse": {"type": "integer", "minimum": 0},
+        "deepUniverse": {"type": "integer", "minimum": 0},
+        "checkpoints": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {"$ref": "#/$defs/runCheckpoint"}
+        },
+        "phases": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {"$ref": "#/$defs/runPhaseGain"}
+        }
+      }
+    },
+    "runCheckpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "apiCovered",
+        "deepCovered",
+        "covered",
+        "uncovered",
+        "coveragePercent"
+      ],
+      "properties": {
+        "name": {"enum": ["runStart", "afterApiPhase", "final"]},
+        "apiCovered": {"type": "integer", "minimum": 0},
+        "deepCovered": {"type": "integer", "minimum": 0},
+        "covered": {"type": "integer", "minimum": 0},
+        "uncovered": {"type": "integer", "minimum": 0},
+        "coveragePercent": {"type": "number", "minimum": 0, "maximum": 100}
+      }
+    },
+    "runPhaseGain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "covered", "coveragePercentagePoints"],
+      "properties": {
+        "name": {"enum": ["api", "deep"]},
+        "covered": {"type": "integer"},
+        "coveragePercentagePoints": {"type": "number"}
+      }
+    },
     "apiSnapshot": {
       "type": "object",
       "additionalProperties": false,

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -55,6 +55,29 @@ def _deep(statuses: list[str], samples: int) -> dict:
     }
 
 
+def _jacoco(api_covered: int, deep_covered: int, api_total: int, deep_total: int) -> str:
+    """A JaCoCo XML naming the same ids the API and deep rosters use.
+
+    The first `api_covered` / `deep_covered` methods of each class carry a
+    covered METHOD counter; the rest are reported but uncovered.
+    """
+    def methods(prefix: str, total: int, covered: int) -> str:
+        return "".join(
+            f'<method name="m{index}" desc="()V" line="{index + 1}">'
+            f'<counter type="METHOD" missed="{0 if index < covered else 1}" '
+            f'covered="{1 if index < covered else 0}"/></method>'
+            for index in range(total)
+        )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?><report name="demo">'
+        f'<package name="example"><class name="example/Api" sourcefilename="Api.java">'
+        f'{methods("Api", api_total, api_covered)}</class>'
+        f'<class name="example/Internal" sourcefilename="Internal.java">'
+        f'{methods("Internal", deep_total, deep_covered)}</class>'
+        "</package></report>"
+    )
+
+
 class FinalizerTests(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -65,6 +88,12 @@ class FinalizerTests(unittest.TestCase):
         path = os.path.join(self.directory.name, name)
         with open(path, "w", encoding="utf-8") as output:
             json.dump(value, output)
+        return path
+
+    def _write_xml(self, name: str, value: str) -> str:
+        path = os.path.join(self.directory.name, name)
+        with open(path, "w", encoding="utf-8") as output:
+            output.write(value)
         return path
 
     def _run(self, include_target_state: bool = True) -> dict:
@@ -125,6 +154,16 @@ class FinalizerTests(unittest.TestCase):
                 ],
             },
         )
+        # Three checkpoints of one run: 1/9 -> 4/9 -> 6/9 of the frozen universe
+        # of 4 API plus 5 deep methods.
+        checkpoints = tuple(
+            self._write_xml(f"jacoco-{name}.xml", _jacoco(api, deep, 4, 5))
+            for name, api, deep in (
+                ("run-start", 1, 0),
+                ("after-api", 3, 1),
+                ("final", 3, 3),
+            )
+        )
         return module.finalize_coverage(
             coordinate=COORDINATE,
             coverage_suite_path="tests/src/com.example/demo/1.0.0/code-coverage-improvement",
@@ -132,10 +171,49 @@ class FinalizerTests(unittest.TestCase):
             api_final_path=final_api,
             deep_baseline_path=baseline_deep,
             deep_final_path=final_deep,
+            jacoco_paths=checkpoints,
             target_state_paths=[state] if include_target_state else [],
             validation_commands=["./gradlew test -Pcoordinates=com.example:demo:1.0.0"],
             output_dir=os.path.join(self.directory.name, "output"),
         )
+
+    def test_run_coverage_is_one_denominator_and_sequential_checkpoints(self) -> None:
+        """Each phase begins at the checkpoint the previous phase ended on."""
+        run = self._run()["runCoverage"]
+
+        self.assertEqual(run["universe"], 9)
+        self.assertEqual((run["apiUniverse"], run["deepUniverse"]), (4, 5))
+        self.assertEqual(
+            [(point["name"], point["covered"]) for point in run["checkpoints"]],
+            [("runStart", 1), ("afterApiPhase", 4), ("final", 6)],
+        )
+        # Every share divides by the same 9, so the phase gains sum to the run's.
+        self.assertEqual(
+            [point["coveragePercent"] for point in run["checkpoints"]],
+            [11.11, 44.44, 66.67],
+        )
+        self.assertEqual(
+            [(phase["name"], phase["covered"]) for phase in run["phases"]],
+            [("api", 3), ("deep", 2)],
+        )
+        gains = sum(phase["coveragePercentagePoints"] for phase in run["phases"])
+        first, last = run["checkpoints"][0], run["checkpoints"][-1]
+        self.assertAlmostEqual(
+            gains, last["coveragePercent"] - first["coveragePercent"], places=2
+        )
+
+    def test_run_coverage_rejects_a_universe_that_moved(self) -> None:
+        """A frozen id missing from a later report is an error, not a zero."""
+        with self.assertRaises(module.FinalizationError) as raised:
+            module._checkpoint(
+                "final",
+                self._write_xml("short.xml", _jacoco(1, 1, 2, 2)),
+                ["example.Api#m0():void", "example.Api#m9():void"],
+                [],
+            )
+
+        self.assertIn("the universe moved", str(raised.exception))
+        self.assertIn("example.Api#m9():void", str(raised.exception))
 
     def test_finalizes_without_target_state_files(self) -> None:
         metrics = self._run(include_target_state=False)
@@ -184,7 +262,7 @@ class FinalizerTests(unittest.TestCase):
         loaded = module.load_validated_final_metrics(
             os.path.join(output, "final-metrics.json")
         )
-        self.assertEqual(loaded["schemaVersion"], "1.0.0")
+        self.assertEqual(loaded["schemaVersion"], "1.1.0")
         with open(
                 os.path.join(output, "final-summary.md"),
                 encoding="utf-8",

--- a/forge/tests/test_make_pr_code_coverage_improvement.py
+++ b/forge/tests/test_make_pr_code_coverage_improvement.py
@@ -18,7 +18,7 @@ class PublisherTests(unittest.TestCase):
 
     def _metrics(self) -> dict:
         return {
-            "schemaVersion": "1.0.0",
+            "schemaVersion": "1.1.0",
             "coordinate": "com.example:demo:1.0.0",
             "coverageSuitePath": "tests/src/com.example/demo/1.0.0/code-coverage-improvement",
             "apiJacoco": {
@@ -98,25 +98,44 @@ class PublisherTests(unittest.TestCase):
                 "./gradlew test -Pcoordinates=com.example:demo:1.0.0"
             ],
             "needsHumanIntervention": True,
+            "runCoverage": {
+                "universe": 30,
+                "apiUniverse": 10,
+                "deepUniverse": 20,
+                "checkpoints": [
+                    {"name": "runStart", "apiCovered": 4, "deepCovered": 2,
+                     "covered": 6, "uncovered": 24, "coveragePercent": 20.0},
+                    {"name": "afterApiPhase", "apiCovered": 8, "deepCovered": 5,
+                     "covered": 13, "uncovered": 17, "coveragePercent": 43.33},
+                    {"name": "final", "apiCovered": 9, "deepCovered": 12,
+                     "covered": 21, "uncovered": 9, "coveragePercent": 70.0},
+                ],
+                "phases": [
+                    {"name": "api", "covered": 7, "coveragePercentagePoints": 23.33},
+                    {"name": "deep", "covered": 8, "coveragePercentagePoints": 26.67},
+                ],
+            },
         }
 
-    def test_body_reports_phase_totals(self) -> None:
+    def test_body_reports_one_denominator_and_sequential_checkpoints(self) -> None:
         body = module.build_pull_request_body(
             "com.example:demo:1.0.0", 8380, self._metrics()
         )
 
-        self.assertIn("### Simple Jacoco guidance phase", body)
-        # `measured`, not `total`: the 6 not-reported entries are methods JaCoCo
-        # can never rule on, so counting them against the run understates it.
-        self.assertIn("Baseline: 4/10 (40.0%)", body)
-        self.assertIn("Final: 8/10 (80.0%)", body)
-        self.assertIn("Delta: +40.0pp", body)
-        self.assertIn("Remaining uncovered: 2", body)
-        self.assertIn("### PGO guidance phase", body)
-        self.assertIn("Final: 12/20 (60.0%)", body)
+        self.assertIn("the 30 library methods JaCoCo can rule on", body)
+        self.assertIn("10 public API methods and 20 internal methods", body)
+        # Each phase starts where the previous one ended, so no checkpoint ever
+        # reads as a fresh baseline lower than the phase before it.
+        self.assertIn("| Run start | 6/30 | 20.0% |", body)
+        self.assertIn("| After Simple Jacoco guidance phase | 13/30 | 43.33% |", body)
+        self.assertIn("| After PGO guidance phase (final) | 21/30 | 70.0% |", body)
+        self.assertIn("- Simple Jacoco guidance phase: +7 methods, +23.33pp", body)
+        self.assertIn("- PGO guidance phase: +8 methods, +26.67pp", body)
+        self.assertIn("- Run total: +15 methods, +50.0pp", body)
+        self.assertIn("- Remaining uncovered: 9 of 30", body)
+        self.assertIn("| Public API | 4/10 | 9/10 | 1 |", body)
+        self.assertIn("| Internal | 2/20 | 12/20 | 8 |", body)
         self.assertNotIn("Sampled PGO", body)
-        self.assertNotIn("84 samples", body)
-
         self.assertIn("Needs human intervention: yes", body)
 
     def test_body_omits_target_rosters_and_validation_commands(self) -> None:
@@ -134,16 +153,15 @@ class PublisherTests(unittest.TestCase):
         self.assertNotIn("No public route.", body)
         self.assertNotIn("attempts: 4, last attempted iteration: 5", body)
 
-    def test_body_combines_both_phases(self) -> None:
+    def test_body_carries_no_phase_local_denominator(self) -> None:
+        """Two phases on their own scales are what made the figures inconsistent."""
         body = module.build_pull_request_body(
             "com.example:demo:1.0.0", 8380, self._metrics()
         )
 
-        # Disjoint universes, so 10 measured API + 20 deep methods add up.
-        self.assertIn("### Both phases combined", body)
-        self.assertIn("Baseline: 9/30 (30.0%)", body)
-        self.assertIn("Final: 20/30 (66.67%)", body)
-        self.assertIn("Delta: +36.67pp", body)
+        self.assertNotIn("Both phases combined", body)
+        for phase_local in ("/10 (", "/20 (", "8/10", "12/20 |  "):
+            self.assertNotIn(phase_local, body)
 
     def test_body_reports_token_usage_in_workflow_order(self) -> None:
         usage = [

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -21,8 +21,14 @@ from typing import Any
 from jsonschema import Draft202012Validator
 
 from utility_scripts.code_coverage_model import parse_inventory_id
+from utility_scripts.code_coverage_jacoco import load_jacoco_method_coverage
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
+
+#: Run checkpoints, in run order. Each is one JaCoCo report, and each phase
+#: begins at the checkpoint the previous phase ended on
+#: (§WF-code-coverage-improvement.4.1).
+CHECKPOINT_NAMES: tuple[str, ...] = ("runStart", "afterApiPhase", "final")
 SCHEMA_FILE = "code_coverage_final_metrics_schema.json"
 TARGET_STATE_SCHEMA_FILE = "code_coverage_target_state_schema.json"
 COORDINATE_PATTERN = re.compile(
@@ -221,6 +227,134 @@ def _deep_snapshot(
         "covered": covered,
         "uncovered": uncovered,
         "coveragePercent": _percent(covered, total),
+    }
+
+
+def _universe_ids(
+        api_baseline_report: dict[str, Any],
+        deep_baseline_report: dict[str, Any],
+        run_start: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """The complete method set every ratio in this run divides by.
+
+    Frozen once, from the run's own inventory and deep rosters, and never
+    recomputed per phase. Inventory entries JaCoCo does not report at all are
+    dropped: no run can cover them, so charging them to a denominator understates
+    every figure that divides by it. The two rosters must not overlap, since the
+    deep roster is by construction the library methods the inventory does not
+    hold, and an overlap would double count (§WF-code-coverage-improvement.4.1).
+    """
+    inventory_ids: list[str] = list(
+        _coverage_statuses(
+            api_baseline_report,
+            "targets",
+            "API baseline",
+            frozenset({"covered", "uncovered", "not-reported"}),
+        )
+    )
+    deep_ids: list[str] = list(
+        _coverage_statuses(
+            deep_baseline_report,
+            "deepMethods",
+            "Deep baseline",
+            frozenset({"covered", "uncovered"}),
+        )
+    )
+    overlap: set[str] = set(inventory_ids) & set(deep_ids)
+    if overlap:
+        raise FinalizationError(
+            f"The API and deep rosters share {len(overlap)} method ids; "
+            f"the coverage universes must be disjoint."
+        )
+    api_ids: list[str] = [
+        method_id for method_id in inventory_ids if method_id in run_start
+    ]
+    if not api_ids and not deep_ids:
+        raise FinalizationError("The coverage universe is empty.")
+    return api_ids, deep_ids
+
+
+def _checkpoint(
+        name: str,
+        jacoco_path: str,
+        api_ids: list[str],
+        deep_ids: list[str],
+) -> dict[str, Any]:
+    """Count one instant of the run over the frozen universe.
+
+    One report, one routine, both universes. Assembling a checkpoint from
+    summary fields that separate phases computed for themselves is what lets two
+    different instants of the run be presented as if they were comparable.
+    """
+    coverage: dict[str, Any] = load_jacoco_method_coverage([jacoco_path])
+    missing: list[str] = [
+        method_id
+        for method_id in api_ids + deep_ids
+        if method_id not in coverage
+    ]
+    if missing:
+        raise FinalizationError(
+            f"Checkpoint '{name}' ({jacoco_path}) does not report "
+            f"{len(missing)} of the frozen universe's methods, so the universe "
+            f"moved during the run; first is '{missing[0]}'."
+        )
+    api_covered: int = sum(1 for i in api_ids if coverage[i].covered)
+    deep_covered: int = sum(1 for i in deep_ids if coverage[i].covered)
+    universe: int = len(api_ids) + len(deep_ids)
+    return {
+        "name": name,
+        "apiCovered": api_covered,
+        "deepCovered": deep_covered,
+        "covered": api_covered + deep_covered,
+        "uncovered": universe - api_covered - deep_covered,
+        "coveragePercent": _percent(api_covered + deep_covered, universe),
+    }
+
+
+def _run_coverage(
+        api_baseline_report: dict[str, Any],
+        deep_baseline_report: dict[str, Any],
+        jacoco_paths: tuple[str, str, str],
+) -> dict[str, Any]:
+    """Whole-run coverage: one denominator, one routine, sequential checkpoints.
+
+    The per-phase blocks record each phase against its own roster, which is what
+    a phase's own guidance is ranked on. This block is the run as a reader sees
+    it: every checkpoint a share of the same complete method count, so a phase's
+    gain is the distance from the previous checkpoint and the phase gains sum to
+    the run's gain (§WF-code-coverage-improvement.4.1).
+    """
+    run_start_coverage: dict[str, Any] = load_jacoco_method_coverage(
+        [jacoco_paths[0]]
+    )
+    api_ids: list[str]
+    deep_ids: list[str]
+    api_ids, deep_ids = _universe_ids(
+        api_baseline_report, deep_baseline_report, run_start_coverage
+    )
+    checkpoints: list[dict[str, Any]] = [
+        _checkpoint(name, path, api_ids, deep_ids)
+        for name, path in zip(CHECKPOINT_NAMES, jacoco_paths)
+    ]
+    phases: list[dict[str, Any]] = [
+        {
+            "name": phase_name,
+            "covered": later["covered"] - earlier["covered"],
+            "coveragePercentagePoints": round(
+                later["coveragePercent"] - earlier["coveragePercent"], 2
+            ),
+        }
+        for phase_name, earlier, later in (
+            ("api", checkpoints[0], checkpoints[1]),
+            ("deep", checkpoints[1], checkpoints[2]),
+        )
+    ]
+    return {
+        "universe": len(api_ids) + len(deep_ids),
+        "apiUniverse": len(api_ids),
+        "deepUniverse": len(deep_ids),
+        "checkpoints": checkpoints,
+        "phases": phases,
     }
 
 
@@ -562,6 +696,7 @@ def finalize_coverage(
         api_final_path: str,
         deep_baseline_path: str,
         deep_final_path: str,
+        jacoco_paths: tuple[str, str, str],
         target_state_paths: list[str],
         validation_commands: list[str],
         output_dir: str,
@@ -599,6 +734,9 @@ def finalize_coverage(
         "schemaVersion": SCHEMA_VERSION,
         "coordinate": coordinate,
         "coverageSuitePath": _suite_path(coverage_suite_path),
+        "runCoverage": _run_coverage(
+            api_baseline_report, deep_baseline_report, jacoco_paths
+        ),
         "apiJacoco": {
             "baseline": api_baseline,
             "final": api_final,
@@ -647,6 +785,9 @@ def build_parser() -> argparse.ArgumentParser:
             "--api-final api-cover-report-5.json "
             "--deep-baseline discovery-report-0.json "
             "--deep-final discovery-report-5.json "
+            "--jacoco-run-start validation/jacoco-0.xml "
+            "--jacoco-after-api discovery/jacoco-deep-0.xml "
+            "--jacoco-final discovery/jacoco-deep-5.xml "
             "--target-state targets.json "
             "--validation-command './gradlew test -Pcoordinates=group:artifact:version' "
             "--output-dir runtime/code-coverage/finalization"
@@ -663,6 +804,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-final", required=True, help="API final JSON.")
     parser.add_argument("--deep-baseline", required=True, help="Deep baseline JSON.")
     parser.add_argument("--deep-final", required=True, help="Deep final JSON.")
+    parser.add_argument(
+        "--jacoco-run-start",
+        required=True,
+        help="JaCoCo XML for the run's first checkpoint, before any phase ran.",
+    )
+    parser.add_argument(
+        "--jacoco-after-api",
+        required=True,
+        help=(
+            "JaCoCo XML for the API/deep phase boundary. This is the deep "
+            "phase's own first report, so both universes are counted from one "
+            "instant rather than from two phases' separate snapshots."
+        ),
+    )
+    parser.add_argument(
+        "--jacoco-final",
+        required=True,
+        help="JaCoCo XML for the run's last checkpoint.",
+    )
     parser.add_argument(
         "--target-state",
         action="append",
@@ -695,6 +855,7 @@ def main() -> int:
             args.api_final,
             args.deep_baseline,
             args.deep_final,
+            (args.jacoco_run_start, args.jacoco_after_api, args.jacoco_final),
             args.target_state_paths,
             args.validation_commands,
             args.output_dir,


### PR DESCRIPTION
Coverage figures published by the code coverage improvement workflow were not
comparable between the two guidance phases, and understated every run.

## The defect

Each phase was reported against its own roster, and the two phases' snapshots
were taken at different points in the run:

- `apiJacoco.final` was the API phase's last report. The deep phase runs after
  it and also covers public API methods, and those were discarded.
- `deepJacoco.baseline` was the deep phase's first report, taken after the API
  phase had already run. Internal methods the API phase covered collaterally
  were charged to the baseline.

Both errors push the same way. On `org.apache.kafka:kafka-streams:3.6.2` (#9055,
PR #9321) the published figures were 34.95% to 63.06%, +28.11pp. Recounted over
one universe the run went 25.34% to 65.19%, +39.85pp — the deep phase alone had
covered 150 public API methods that were never counted.

Presenting the two phases against a shared denominator without fixing this makes
it worse, not better: the PGO phase then reads as restarting from a number lower
than the one the previous phase ended on.

## The rule

`§WF-code-coverage-improvement.4.1` states the accounting contract, and
`code_coverage_finalize.py` enforces it:

1. **One universe, frozen once.** The denominator is the complete set of library
   method ids JaCoCo can rule on — the inventory's reportable entries plus the
   deep roster, disjoint by construction. Resolved once from the run's own
   rosters, never recomputed per phase. Entries JaCoCo does not report are
   excluded, since no run can cover them.
2. **One report per checkpoint, one routine.** A checkpoint counts both universes
   from a single JaCoCo report by looking up the frozen ids. Summary fields that
   separate phases computed for themselves are never added together — they
   describe different instants of the run. The API/deep boundary is therefore
   read from the deep phase's own first report.
3. **A missing id is an error, not a zero.** A frozen id absent from a later
   report means the universe moved, and finalization fails rather than quietly
   dividing by less.

Each phase's gain is the distance between consecutive checkpoints, the phase
gains sum to the run's gain, and the separate "Both phases combined" section is
gone because it is now addition the reader can do.

## Changes

- `code_coverage_finalize.py`: new `runCoverage` block with the three
  checkpoints, plus `--jacoco-run-start`, `--jacoco-after-api`, `--jacoco-final`.
  The per-phase `apiJacoco`/`deepJacoco` blocks are unchanged; each phase's own
  guidance is ranked against its own roster, so they stay as phase records.
- `code_coverage_final_metrics_schema.json`: `runCoverage`, schema version 1.1.0.
- `make_pr_code_coverage_improvement.py`: renders the checkpoint table and
  per-phase gains.
- `states.yaml`: passes the three checkpoint reports.

## Verification

Replaying the kafka-streams artifacts through the new finalizer reproduces the
corrected figures exactly, and the intermediate values match the four numbers the
old pipeline published (994, 2688, 1475, 1768), so only the two missing
checkpoints changed. The two JaCoCo report families were confirmed identical in
scope at the phase boundary — 19336 methods, same counts from both — before
being used across it.

Full forge suite: 558 tests, no new failures.
